### PR TITLE
add a conflict due to OpenMP

### DIFF
--- a/packages/cosmo/package.py
+++ b/packages/cosmo/package.py
@@ -54,6 +54,7 @@ class Cosmo(MakefilePackage):
     variant('slave', default='tsa', description='Build on slave tsa or daint', multi=False)
     variant('eccodes', default=False, description='Build with eccodes instead of grib-api')
 
+    conflicts('+cppdycore', when='cosmo_target=cpu')
     build_directory = 'cosmo/ACC'
 
     def setup_environment(self, spack_env, run_env):

--- a/packages/cosmo/package.py
+++ b/packages/cosmo/package.py
@@ -54,7 +54,7 @@ class Cosmo(MakefilePackage):
     variant('slave', default='tsa', description='Build on slave tsa or daint', multi=False)
     variant('eccodes', default=False, description='Build with eccodes instead of grib-api')
 
-    conflicts('+cppdycore', when='cosmo_target=cpu')
+    conflicts('+cppdycore', when='%pgi cosmo_target=cpu')
     build_directory = 'cosmo/ACC'
 
     def setup_environment(self, spack_env, run_env):


### PR DESCRIPTION
I think in case of cpu, gridtools will always build with OpenMP. 
This will be incompatible with pgi Fortran cpu that ships a different openmp. 