### PR TITLE
make explicit use of gcc for C projects

### DIFF
--- a/packages/claw/package.py
+++ b/packages/claw/package.py
@@ -23,7 +23,7 @@ class Claw(CMakePackage):
     version('1.2.0', commit='fc9c50fe02be97b910ff9c7015064f89be88a3a2', submodules=True)
     version('1.1.0', commit='16b165a443b11b025a77cad830b1280b8c9bcf01', submodules=True)
 
-    depends_on('cmake@3.0:', type='build')
+    depends_on('cmake@3.0:%gcc', type='build')
     depends_on('java@8:', when="@2.0:")
     depends_on('java@7:', when="@1.1.0:1.2.3")
     depends_on('ant@1.9:')

--- a/packages/cosmo-dycore/package.py
+++ b/packages/cosmo-dycore/package.py
@@ -48,6 +48,7 @@ class CosmoDycore(CMakePackage):
     depends_on('mpi', type=('build', 'run'))
     depends_on('cuda', type=('build', 'run'))
     depends_on('slurm', type='run')
+    depends_on('cmake@3.12:%gcc', type='build')
 
     root_cmakelists_dir='dycore'
     

--- a/packages/cosmo-grib-api/package.py
+++ b/packages/cosmo-grib-api/package.py
@@ -21,10 +21,10 @@ class CosmoGribApi(AutotoolsPackage):
     version('1.13.1', commit='d3deb226c90177a586e4b7181451944f5f47d243')
     
     depends_on('m4')
-    depends_on('autoconf')
-    depends_on('automake')
-    depends_on('libtool')
-    depends_on('jasper@1.900.1')
+    depends_on('autoconf%gcc')
+    depends_on('automake%gcc')
+    depends_on('libtool%gcc')
+    depends_on('jasper@1.900.1%gcc')
     
     force_autoreconf = True
  

--- a/packages/cosmo-grib-api/package.py
+++ b/packages/cosmo-grib-api/package.py
@@ -21,9 +21,9 @@ class CosmoGribApi(AutotoolsPackage):
     version('1.13.1', commit='d3deb226c90177a586e4b7181451944f5f47d243')
     
     depends_on('m4')
-    depends_on('autoconf%gcc')
-    depends_on('automake%gcc')
-    depends_on('libtool%gcc')
+    depends_on('autoconf')
+    depends_on('automake')
+    depends_on('libtool')
     depends_on('jasper@1.900.1%gcc')
     
     force_autoreconf = True

--- a/packages/cosmo-grib-api/package.py
+++ b/packages/cosmo-grib-api/package.py
@@ -20,10 +20,10 @@ class CosmoGribApi(AutotoolsPackage):
     version('1.20.0.2', commit='00d986cd24a1470232067e6011e434a1677acd94')
     version('1.13.1', commit='d3deb226c90177a586e4b7181451944f5f47d243')
     
-    depends_on('m4')
-    depends_on('autoconf')
-    depends_on('automake')
-    depends_on('libtool')
+    depends_on('m4%gcc')
+    depends_on('autoconf%gcc')
+    depends_on('automake%gcc')
+    depends_on('libtool%gcc')
     depends_on('jasper@1.900.1%gcc')
     
     force_autoreconf = True

--- a/packages/cosmo/package.py
+++ b/packages/cosmo/package.py
@@ -36,7 +36,7 @@ class Cosmo(MakefilePackage):
     depends_on('serialbox@2.6.0', when='%gcc +serialize')
     depends_on('mpi', type=('build', 'run'))
     depends_on('libgrib1')
-    depends_on('jasper@1.900.1')
+    depends_on('jasper@1.900.1%gcc')
     depends_on('cosmo-grib-api-definitions', when='~eccodes')
     depends_on('cosmo-eccodes-definitions@2.14.1.2', when='+eccodes')
     depends_on('perl@5.16.3:')

--- a/packages/gridtools/package.py
+++ b/packages/gridtools/package.py
@@ -35,7 +35,7 @@ class Gridtools(CMakePackage):
     variant('enable_bindings_gerneration', default=True, description="Build with bindings generation")
 
     depends_on('ncurses')
-    depends_on('cmake')
+    depends_on('cmake@3.14.5:%gcc')
     depends_on('boost@1.67.0:')
     depends_on('mpi',  type=('build', 'run'))
     depends_on('cuda', when='cosmo_target=gpu',  type=('build', 'run'))

--- a/sysconfigs/admin-daint/packages.yaml
+++ b/sysconfigs/admin-daint/packages.yaml
@@ -13,10 +13,10 @@ packages:
             pkgconfig: [pkg-config]
     autoconf:
         paths:
-             autoconf@2.69: /usr
+             autoconf@2.69%gcc: /usr
     automake:
         paths:
-             automake@1.15.1: /usr
+             automake@1.15.1%gcc: /usr
     binutils:
         variants: +gold~headers+libiberty+nls~plugin
         paths:
@@ -119,13 +119,13 @@ packages:
             intel-mkl@2019.1.144%cce~ilp64 threads=none:   /opt/intel
     libtool:
         paths:
-             libtool@2.4.6: /usr
+             libtool@2.4.6%gcc: /usr
     lz4:
         paths:
              lz4@1.8.0: /usr
     m4:
         paths:
-             m4@1.4.18: /usr
+             m4@1.4.18%gcc: /usr
     mpich:
         buildable: false
         modules:

--- a/sysconfigs/admin-tsa/packages.yaml
+++ b/sysconfigs/admin-tsa/packages.yaml
@@ -37,13 +37,13 @@ packages:
       bzip2@1.0.6: /usr
   m4:
     paths: 
-      m4@1.4.16: /usr
+      m4@1.4.16%gcc: /usr
   automake:
     paths:
-      automake@1.13.4: /usr
+      automake@1.13.4%gcc: /usr
   autoconf:
     paths:
-      autoconf@2.69: /usr
+      autoconf@2.69%gcc: /usr
   bison:
     paths:
       bison@3.0.4: /usr
@@ -55,10 +55,10 @@ packages:
       libxml2@2.9.9: /usr
   libtool:
     paths:
-      libtool@2.4.2: /usr
+      libtool@2.4.2%gcc: /usr
   jasper:
     paths:
-      jasper@1.900.1: /usr/bin
+      jasper@1.900.1%gcc: /usr/bin
   slurm:
     modules:
       slurm@19.05.04: slurm/19.05.04

--- a/sysconfigs/daint/packages.yaml
+++ b/sysconfigs/daint/packages.yaml
@@ -13,10 +13,10 @@ packages:
             pkgconfig: [pkg-config]
     autoconf:
         paths:
-             autoconf@2.69: /usr
+             autoconf@2.69%gcc: /usr
     automake:
         paths:
-             automake@1.15.1: /usr
+             automake@1.15.1%gcc: /usr
     binutils:
         variants: +gold~headers+libiberty+nls~plugin
         paths:
@@ -119,13 +119,13 @@ packages:
             intel-mkl@2019.1.144%cce~ilp64 threads=none:   /opt/intel
     libtool:
         paths:
-             libtool@2.4.6: /usr
+             libtool@2.4.6%gcc: /usr
     lz4:
         paths:
              lz4@1.8.0: /usr
     m4:
         paths:
-             m4@1.4.18: /usr
+             m4@1.4.18%gcc: /usr
     mpich:
         buildable: false
         modules:

--- a/sysconfigs/tsa/packages.yaml
+++ b/sysconfigs/tsa/packages.yaml
@@ -34,13 +34,13 @@ packages:
       perl@5.16.3: /usr
   m4:
     paths: 
-      m4@1.4.16: /usr
+      m4@1.4.16%gcc: /usr
   automake:
     paths:
-      automake@1.13.4: /usr
+      automake@1.13.4%gcc: /usr
   autoconf:
     paths:
-      autoconf@2.69: /usr
+      autoconf@2.69%gcc: /usr
   bison:
     paths:
       bison@3.0.4: /usr
@@ -52,10 +52,10 @@ packages:
       libxml2@2.9.9: /usr
   libtool:
     paths:
-      libtool@2.4.2: /usr
+      libtool@2.4.2%gcc: /usr
   jasper:
     paths:
-      jasper@1.900.1: /usr/bin
+      jasper@1.900.1%gcc: /usr/bin
   slurm:
     modules:
       slurm@19.05.04: slurm/19.05.04


### PR DESCRIPTION
The proposal here is to explicitly force gcc on dependencies of packages that are purely C/C++, to avoid falling into pgi when trigger from a top level package that had Fortran and requested pgi. 
The dependencies coming from already C++ projects like dycore should not be a problem, since the dycore should itself be compiled with gcc, but I thought being explicit everywhere would anyhow be a good practice. 

The problem came from a system that didnt not contain jasper, which propagated C dependencies being compiled with pgi. In the end openssl failed to compile with pgi

What do you think?

```
cosmo@aws_5.07.mch1.0.p4%pgi@19.10~claw cosmo_target=cpu ~cppdycore~debug~eccodes+parallel~pollen real_type=double ~serialize slave=aws arch=linux-ubuntu18.04-skylake_avx512
    ^cosmo-grib-api-definitions@1.20.0.2%pgi@19.10 arch=linux-ubuntu18.04-skylake_avx512
        ^cosmo-grib-api@1.20.0.2%pgi@19.10 arch=linux-ubuntu18.04-skylake_avx512
            ^autoconf@2.69%pgi@19.10 arch=linux-ubuntu18.04-skylake_avx512
            ^automake@1.13.4%pgi@19.10 arch=linux-ubuntu18.04-skylake_avx512
            ^jasper@1.900.1%pgi@19.10 build_type=Release +jpeg~opengl patches=db104400a2e72f610b8fa4d061a32282254819c70b024ef1cf99fef64aca67e3 +shared arch=linux-ubuntu18.04-skylake_avx512
                ^libjpeg-turbo@2.0.3%pgi@19.10 arch=linux-ubuntu18.04-skylake_avx512
                    ^cmake@3.16.2%pgi@19.10~doc+ncurses+openssl+ownlibs~qt arch=linux-ubuntu18.04-skylake_avx512
                        ^ncurses@6.1%pgi@19.10~symlinks~termlib arch=linux-ubuntu18.04-skylake_avx512
                        ^openssl@1.1.1d%pgi@19.10+systemcerts arch=linux-ubuntu18.04-skylake_avx512
                            ^perl@5.16.3%pgi@19.10+cpanm patches=0eac10ed90aeb0459ad8851f88081d439a4e41978e586ec743069e8b059370ac +shared+threads arch=linux-ubuntu18.04-skylake_avx512
                            ^zlib@1.2.11%pgi@19.10+optimize+pic+shared arch=linux-ubuntu18.04-skylake_avx512
                    ^nasm@2.14.02%pgi@19.10 arch=linux-ubuntu18.04-skylake_avx512
            ^libtool@2.4.2%pgi@19.10 arch=linux-ubuntu18.04-skylake_avx512
            ^m4@1.4.16%pgi@19.10+sigsegv arch=linux-ubuntu18.04-skylake_avx512
    ^cuda@10.1.243%pgi@19.10 arch=linux-ubuntu18.04-skylake_avx512
    ^libgrib1@2019-11-22%pgi@19.10 arch=linux-ubuntu18.04-skylake_avx512
```