### PR TITLE
Add production variant

### DIFF
--- a/packages/cosmo-dycore/package.py
+++ b/packages/cosmo-dycore/package.py
@@ -34,8 +34,7 @@ class CosmoDycore(CMakePackage):
     
     version('master', branch='master')
     
-    variant('build_type', default='Release', description='Build type', values=('Debug', 'Release', 'Debu
-gRelease'))
+    variant('build_type', default='Release', description='Build type', values=('Debug', 'Release', 'DebugRelease'))
     variant('build_tests', default=True, description="Compile Dycore unittests & regressiontests")
     variant('cosmo_target', default='gpu', description='Build target gpu or cpu', values=('gpu', 'cpu'), multi=False)
     variant('real_type', default='double', description='Build with double or single precision enabled', values=('double', 'float'), multi=False)

--- a/packages/cosmo-dycore/package.py
+++ b/packages/cosmo-dycore/package.py
@@ -33,7 +33,9 @@ class CosmoDycore(CMakePackage):
     maintainers = ['elsagermann']
     
     version('master', branch='master')
-
+    
+    variant('build_type', default='Release', description='Build type', values=('Debug', 'Release', 'Debu
+gRelease'))
     variant('build_tests', default=True, description="Compile Dycore unittests & regressiontests")
     variant('cosmo_target', default='gpu', description='Build target gpu or cpu', values=('gpu', 'cpu'), multi=False)
     variant('real_type', default='double', description='Build with double or single precision enabled', values=('double', 'float'), multi=False)
@@ -52,7 +54,7 @@ class CosmoDycore(CMakePackage):
     depends_on('cuda', type=('build', 'run'))
     depends_on('slurm', type='run')
 
-    conflicts('+production', when='+debug')
+    conflicts('+production', when='build_type=Debug')
     conflicts('+production', when='cosmo_target=cpu')
     conflicts('+production', when='+pmeters')
 
@@ -76,10 +78,7 @@ class CosmoDycore(CMakePackage):
       GridToolsDir = spec['gridtools'].prefix + '/lib/cmake'
       
       args.append('-DGridTools_DIR={0}'.format(GridToolsDir))  
-      if spec.variants['debug'].value:
-          args.append('-DCMAKE_BUILD_TYPE=DEBUG')
-      else:
-          args.append('-DCMAKE_BUILD_TYPE=Release')
+      args.append('-DCMAKE_BUILD_TYPE={0}'.format(self.spec.variants['build_type'].value))
       args.append('-DCMAKE_INSTALL_PREFIX={0}'.format(self.prefix))
       args.append('-DCMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY=ON')
       args.append('-DBoost_USE_STATIC_LIBS=ON')

--- a/packages/cosmo-dycore/package.py
+++ b/packages/cosmo-dycore/package.py
@@ -41,7 +41,9 @@ class CosmoDycore(CMakePackage):
     variant('slave', default='tsa', description='Build on slave tsa or daint', multi=False)
     variant('pmeters', default=False, description="Enable the performance meters for the dycore stencils")
     variant('data_path', default='.', description='Serialization data path', multi=False)
-    
+    variant('debug', default=False, description='Build debug mode')
+    variant('production', default=False, description='Force all variants to be the ones used in production')   
+ 
     depends_on('gridtools@1.1.3 cosmo_target=gpu', when='cosmo_target=gpu')
     depends_on('gridtools@1.1.3 cosmo_target=cpu', when='cosmo_target=cpu')
     depends_on('boost@1.67.0')
@@ -49,6 +51,10 @@ class CosmoDycore(CMakePackage):
     depends_on('mpi', type=('build', 'run'))
     depends_on('cuda', type=('build', 'run'))
     depends_on('slurm', type='run')
+
+    conflicts('+production', when='+debug')
+    conflicts('+production', when='cosmo_target=cpu')
+    conflicts('+production', when='+pmeters')
 
     root_cmakelists_dir='dycore'
     
@@ -70,7 +76,10 @@ class CosmoDycore(CMakePackage):
       GridToolsDir = spec['gridtools'].prefix + '/lib/cmake'
       
       args.append('-DGridTools_DIR={0}'.format(GridToolsDir))  
-      args.append('-DCMAKE_BUILD_TYPE=Release')
+      if spec.variants['debug'].value:
+          args.append('-DCMAKE_BUILD_TYPE=DEBUG')
+      else:
+          args.append('-DCMAKE_BUILD_TYPE=Release')
       args.append('-DCMAKE_INSTALL_PREFIX={0}'.format(self.prefix))
       args.append('-DCMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY=ON')
       args.append('-DBoost_USE_STATIC_LIBS=ON')

--- a/packages/cosmo/package.py
+++ b/packages/cosmo/package.py
@@ -31,6 +31,8 @@ class Cosmo(MakefilePackage):
     depends_on('cosmo-dycore%gcc cosmo_target=cpu', when='cosmo_target=cpu +cppdycore')
     depends_on('cosmo-dycore%gcc real_type=float', when='real_type=float +cppdycore')
     depends_on('cosmo-dycore%gcc real_type=double', when='real_type=double +cppdycore')
+    depends_on('cosmo-dycore%gcc +production', when='+production +cppdycore')
+
     depends_on('serialbox@2.6.0%pgi@19.9-gcc', when='%pgi@19.9 +serialize')
     depends_on('serialbox@2.6.0%pgi@19.7.0-gcc', when='%pgi@19.7.0 +serialize')
     depends_on('serialbox@2.6.0', when='%gcc +serialize')
@@ -53,6 +55,14 @@ class Cosmo(MakefilePackage):
     variant('claw', default=False, description='Build with claw-compiler')
     variant('slave', default='tsa', description='Build on slave tsa or daint', multi=False)
     variant('eccodes', default=False, description='Build with eccodes instead of grib-api')
+    variant('production', default=False, description='Force all variants to be the ones used in production')
+    
+    conflicts('+production', when='~cppdycore')
+    conflicts('+production', when='+serialize')
+    conflicts('+production', when='+debug')
+    conflicts('+production', when='~claw')
+    conflicts('+production', when='~parallel')
+    conflicts('+production', when='cosmo_target=cpu')
 
     build_directory = 'cosmo/ACC'
 


### PR DESCRIPTION
How about adding a production variant that will fix all options that are a must for producing a production executable, and avoid mistakes like compiling a production exe w/o claw?
