### PR TITLE
add metamodules for netcdf

### DIFF
--- a/packages/cosmo/package.py
+++ b/packages/cosmo/package.py
@@ -8,7 +8,11 @@ from spack import *
 
 
 class Cosmo(MakefilePackage):
-    """COSMO: Numerical Weather Prediction Model. Needs access to private GitHub."""
+    """COSMO: Numerical Weather Prediction Model. Needs access to private GitHub.
+       This package is expecting the following variables to be defined in the module environment:
+       NETCDFF_DIR: root directory to netcdf-fortran installation
+       NETCDFC_DIR: root directory to netcdf-c installation
+    """
 
     homepage = "http://www.cosmo-model.org"
     url      = "cosmo"

--- a/packages/cosmo/package.py
+++ b/packages/cosmo/package.py
@@ -133,12 +133,8 @@ class Cosmo(MakefilePackage):
                 OptionsFileName += '.cray'
             OptionsFileName += '.' + spec.variants['cosmo_target'].value
             optionsfilter = FileFilter('Options.lib.' + spec.variants['cosmo_target'].value)
-            if self.spec.variants['slave'].value == 'tsa':
-                optionsfilter.filter('NETCDFI *=.*', 'NETCDFI = -I{0}/include'.format(spec['netcdf-fortran'].prefix))
-                optionsfilter.filter('NETCDFL *=.*', 'NETCDFL = -L{0}/lib -lnetcdff -L{1}/lib -lnetcdf'.format(spec['netcdf-fortran'].prefix, spec['netcdf-c'].prefix))
-            else:
-                optionsfilter.filter('NETCDFI *=.*', 'NETCDFI = -I$(NETCDF_DIR)/include')
-                optionsfilter.filter('NETCDFL *=.*', 'NETCDFL = -L$(NETCDF_DIR)/lib -lnetcdff -lnetcdf')
+            optionsfilter.filter('NETCDFI *=.*', 'NETCDFI = -I{NETCDFF_DIR}/include')
+            optionsfilter.filter('NETCDFL *=.*', 'NETCDFL = -L{NETCDFF_DIR}/lib -lnetcdff -L{NETCDFC_DIR}/lib -lnetcdf')
             if '+eccodes' in spec:
               optionsfilter.filter('GRIBAPIL *=.*', 'GRIBAPIL = -L$(GRIBAPI_DIR)/lib -leccodes_f90 -leccodes -L$(JASPER_DIR)/lib -ljasper')
             makefile.filter('/Options', '/' + OptionsFileName)

--- a/sysconfigs/tsa/modules/meta-netcdf-c/4.4.5
+++ b/sysconfigs/tsa/modules/meta-netcdf-c/4.4.5
@@ -1,0 +1,18 @@
+#%Module1.0
+## Module file created by spack (https://github.com/spack/spack) on 2020-03-22 15:18:20.526181
+##
+## cosmo@master%pgi@19.9~claw cosmo_target=cpu +cppdycore~debug~eccodes+parallel real_type=double ~serialize slave=tsa arch=linux-rhel7-skylake_avx512/nkoxtws
+##
+
+
+module-whatis "COSMO: Numerical Weather Prediction Model. Needs access to private GitHub."
+
+proc ModulesHelp { } {
+puts stderr "COSMO: Numerical Weather Prediction Model. Needs access to private"
+puts stderr "GitHub."
+}
+
+prereq netcdf/4.7.0-pgi-19.9-gcc-8.3.0
+
+setenv NETCDFC_DIR $env(EBROOTNETCDF)
+

--- a/sysconfigs/tsa/modules/meta-netcdf-c/gcc-4.7.0
+++ b/sysconfigs/tsa/modules/meta-netcdf-c/gcc-4.7.0
@@ -1,0 +1,12 @@
+#%Module1.0
+
+module-whatis "meta-package for netcdf-c"
+
+proc ModulesHelp { } {
+puts stderr "meta-package for netcdf-c"
+}
+
+source /apps/arolla/UES/jenkins/RH7.6/gnu/19.2/easybuild/modules/all/netcdf/4.7.0-fosscuda-2019b
+
+setenv NETCDFC_DIR $env(EBROOTNETCDF)
+

--- a/sysconfigs/tsa/modules/meta-netcdf-c/pgi-4.7.0
+++ b/sysconfigs/tsa/modules/meta-netcdf-c/pgi-4.7.0
@@ -1,0 +1,11 @@
+#%Module1.0
+
+module-whatis "meta-package for netcdf-c"
+
+proc ModulesHelp { } {
+puts stderr "meta-package for netcdf-c"
+}
+
+source /apps/arolla/UES/jenkins/RH7.6/pgi/19.9/easybuild/modules/all/netcdf/4.7.0-pgi-19.9-gcc-8.3.0
+setenv NETCDFC_DIR $env(EBROOTNETCDF)
+

--- a/sysconfigs/tsa/modules/meta-netcdf-f/gcc-4.4.5
+++ b/sysconfigs/tsa/modules/meta-netcdf-f/gcc-4.4.5
@@ -1,0 +1,12 @@
+#%Module1.0
+
+module-whatis "meta-package for netcdf"
+
+proc ModulesHelp { } {
+puts stderr "metapackage for netcdf"
+}
+
+source /apps/arolla/UES/jenkins/RH7.6/gnu/19.2/easybuild/modules/all/netcdf-fortran/4.4.5-fosscuda-2019b
+
+setenv NETCDFF_DIR $env(EBROOTNETCDFMINFORTRAN)
+

--- a/sysconfigs/tsa/modules/meta-netcdf-f/pgi-4.4.5
+++ b/sysconfigs/tsa/modules/meta-netcdf-f/pgi-4.4.5
@@ -1,0 +1,12 @@
+#%Module1.0
+
+module-whatis "meta-package for netcdf"
+
+proc ModulesHelp { } {
+puts stderr "meta-package for netcdf"
+}
+
+source /apps/arolla/UES/jenkins/RH7.6/pgi/19.9/easybuild/modules/all/netcdf-fortran/4.4.5-pgi-19.9-gcc-8.3.0
+
+setenv NETCDFF_DIR $env(EBROOTNETCDFMINFORTRAN)
+

--- a/sysconfigs/tsa/packages.yaml
+++ b/sysconfigs/tsa/packages.yaml
@@ -22,13 +22,13 @@ packages:
       openmpi@4.0.2%pgi: /apps/arolla/UES/jenkins/RH7.6/pgi/19.9/easybuild/software/OpenMPI/4.0.2-PGI-19.9-GCC-8.3.0-cuda-10.1
       openmpi@4.0.2%gcc: /apps/arolla/UES/jenkins/RH7.6/gnu/19.2/easybuild/software/OpenMPI/4.0.2-gcccuda-2019b-cuda-10.1
   netcdf-fortran:
-    paths:
-      netcdf-fortran@4.4.5%pgi: /apps/arolla/UES/jenkins/RH7.6/pgi/19.9/easybuild/software/netCDF-Fortran/4.4.5-PGI-19.9-GCC-8.3.0/
-      netcdf-fortran@4.4.5%gcc: /apps/arolla/UES/jenkins/RH7.6/gnu/19.2/easybuild/software/netCDF-Fortran/4.4.5-fosscuda-2019b
+    modules:
+      netcdf-fortran@4.4.5%pgi: meta-netcdf-f/pgi-4.4.5
+      netcdf-fortran@4.4.5%gcc: meta-netcdf-f/gcc-4.4.5
   netcdf-c:
-    paths:
-      netcdf-c@4.7.0%pgi : /apps/arolla/UES/jenkins/RH7.6/pgi/19.9/easybuild/software/netCDF/4.7.0-PGI-19.9-GCC-8.3.0
-      netcdf-c@4.7.0%gcc : /apps/arolla/UES/jenkins/RH7.6/gnu/19.2/easybuild/software/netCDF/4.7.0-fosscuda-2019b
+    modules:
+      netcdf-c@4.7.0%pgi: meta-netcdf-c/pgi-4.7.0
+      netcdf-c@4.7.0%gcc: meta-netcdf-c/gcc-4.7.0
   perl:
     paths: 
       perl@5.16.3: /usr


### PR DESCRIPTION
This is a proposal for discussion, DO NOT MERGE.

The idea behind is to avoid this kind of customization
https://github.com/MeteoSwiss-APN/spack-mch/blob/master/packages/cosmo/package.py#L136
Since it opens the doors to end up with a large multiplicity of recipes for building for different machines difficult to maintain. Also it makes a contract impossible to define. 
A contract in this context should specify what needs to be defined in the environment, as a requirement for the build of spack, i.e. NETCDF_DIR. And I think for maintenance is important there is one contract instead of one per machine. 

The underlying problem is that each machine will define env vars in modules in a different way. 
Here the proposal is to have meta modules that redirect the EBROOTNET... to the variable defined by the contract of cosmo/package.py
For ex: 
https://github.com/MeteoSwiss-APN/spack-mch/pull/10/files#diff-ecd6eaa50e6ff08a5f39ac327da8a952R11

Alternatively we can specify the full path like here: 
https://github.com/MeteoSwiss-APN/spack-mch/blob/master/sysconfigs/tsa/packages.yaml#L26

The difference is that with the meta-module you can define more variables, for contracts that are not simply <package>_DIR

The second goal of this approach would be to reduce the machine dimensionality  of all the Options.<machine>.<compiler>.<target> and have a more homogeneous way since atm we have that inside and outside of spack.

TBD