### PR TITLE
RM: claw%gcc and add libxml2 + libjpeg

### DIFF
--- a/packages/claw/package.py
+++ b/packages/claw/package.py
@@ -24,11 +24,11 @@ class Claw(CMakePackage):
     version('1.2.0', commit='fc9c50fe02be97b910ff9c7015064f89be88a3a2', submodules=True)
     version('1.1.0', commit='16b165a443b11b025a77cad830b1280b8c9bcf01', submodules=True)
 
-    depends_on('cmake@3.0:%gcc', type='build')
+    depends_on('cmake@3.0:', type='build')
     depends_on('java@8:', when="@2.0:")
     depends_on('java@7:', when="@1.1.0:1.2.3")
     depends_on('ant@1.9:%gcc')
-    depends_on('libxml2')
+    depends_on('libxml2%gcc')
     depends_on('bison%gcc')
     
     def setup_environment(self, spack_env, run_env):

--- a/packages/cosmo-dycore/package.py
+++ b/packages/cosmo-dycore/package.py
@@ -48,7 +48,7 @@ class CosmoDycore(CMakePackage, CudaPackage):
     depends_on('serialbox@2.6.0', when='+build_tests')
     depends_on('mpi', type=('build', 'run'))
     depends_on('slurm', type='run')
-    depends_on('cmake@3.12:%gcc', type='build')
+    depends_on('cmake@3.12:', type='build')
 
     conflicts('+production', when='build_type=Debug')
     conflicts('+production', when='cosmo_target=cpu')

--- a/packages/gridtools/package.py
+++ b/packages/gridtools/package.py
@@ -33,7 +33,7 @@ class Gridtools(CMakePackage,  CudaPackage):
     variant('enable_bindings_gerneration', default=True, description="Build with bindings generation")
 
     depends_on('ncurses')
-    depends_on('cmake@3.14.5:%gcc')
+    depends_on('cmake@3.14.5:')
     depends_on('boost@1.67.0:')
     depends_on('mpi',  type=('build', 'run'))
 

--- a/sysconfigs/daint/packages.yaml
+++ b/sysconfigs/daint/packages.yaml
@@ -124,6 +124,9 @@ packages:
     libtool:
         paths:
              libtool@2.4.6%gcc: /usr
+    libxml2:
+        paths:
+            libxml2%gcc: /usr
     lz4:
         paths:
              lz4@1.8.0: /usr
@@ -164,6 +167,9 @@ packages:
     openssl:
         paths:
              openssl@1.1.0i: /usr
+    openjdk:
+        paths:
+            openjdk%gcc: /usr
     papi:
         buildable: false
         modules:


### PR DESCRIPTION
The spec cosmo%pgi +claw is not working at the moment because even tough we force claw to take cmake%gcc the concretizer still wants to use cmake%pgi. This PR therefore aims to solve the problem by removing the force use of cmake%gcc. It also adds the pre-installed paths of libxml2 & openjdk.