### PR TITLE
FIX: gridtools and dycore CudaPackage

### DIFF
--- a/packages/cosmo-dycore/package.py
+++ b/packages/cosmo-dycore/package.py
@@ -25,7 +25,7 @@
 from spack import *
 
 
-class CosmoDycore(CMakePackage, CudaPackage):
+class CosmoDycore(CMakePackage):
     """FIXME: Put a proper description of your package here."""
     
     homepage = "https://github.com/COSMO-ORG/cosmo/tree/master/dycore"
@@ -40,8 +40,10 @@ class CosmoDycore(CMakePackage, CudaPackage):
     variant('slave', default='tsa', description='Build on slave tsa or daint', multi=False)
     variant('pmeters', default=False, description="Enable the performance meters for the dycore stencils")
     variant('data_path', default='.', description='Serialization data path', multi=False)
-    variant('production', default=False, description='Force all variants to be the ones used in production')   
-   
+    variant('production', default=False, description='Force all variants to be the ones used in production')
+    variant('cuda_arch', default='none', description='Build with cuda_arch', values=('70', '60', '37'), multi=False)
+    variant('cuda', default=True, description='Build with cuda or target gpu')
+
     depends_on('gridtools@1.1.3 +cuda', when='+cuda')
     depends_on('gridtools@1.1.3 ~cuda cuda_arch=none', when='~cuda')
     depends_on('boost@1.67.0')
@@ -49,6 +51,7 @@ class CosmoDycore(CMakePackage, CudaPackage):
     depends_on('mpi', type=('build', 'run'))
     depends_on('slurm', type='run')
     depends_on('cmake@3.12:%gcc', type='build')
+    depends_on('cuda', when='+cuda', type=('build', 'run'))
 
     conflicts('+production', when='build_type=Debug')
     conflicts('+production', when='cosmo_target=cpu')
@@ -102,7 +105,7 @@ class CosmoDycore(CMakePackage, CudaPackage):
           args.append('-DENABLE_CUDA=ON')
           cuda_arch = spec.variants['cuda_arch'].value
           if cuda_arch is not None:
-              args.append('-DCUDA_ARCH=sm_{0}'.format(cuda_arch[0]))
+              args.append('-DCUDA_ARCH=sm_{0}'.format(cuda_arch))
           args.append('-DDYCORE_TARGET_ARCHITECTURE=CUDA')
       # target=cpu
       else:

--- a/packages/gridtools/package.py
+++ b/packages/gridtools/package.py
@@ -6,7 +6,7 @@
 from spack import *
 
 
-class Gridtools(CMakePackage,  CudaPackage):
+class Gridtools(CMakePackage):
     """The GridTools framework is a set of libraries and utilities to develop performance portable applications in the area of weather and climate."""
     
     homepage = "https://github.com/GridTools/gridtools.git"
@@ -31,11 +31,14 @@ class Gridtools(CMakePackage,  CudaPackage):
     variant('no_boost_cmake', default=True, description="Build with no boost for CMake")
     variant('export_no_package_registery', default=True, description="Build with export no package registery")
     variant('enable_bindings_gerneration', default=True, description="Build with bindings generation")
+    variant('cuda_arch', default='none', description='Build with cuda_arch', values=('70', '60', '37'), multi=False)
+    variant('cuda', default=True, description='Build with cuda or target gpu')
 
     depends_on('ncurses')
     depends_on('cmake@3.14.5:%gcc')
     depends_on('boost@1.67.0:')
     depends_on('mpi',  type=('build', 'run'))
+    depends_on('cuda', when='+cuda', type=('build', 'run'))
 
     def cmake_args(self):
       spec = self.spec
@@ -82,7 +85,7 @@ class Gridtools(CMakePackage,  CudaPackage):
         args.append('-DGT_USE_MPI=OFF')
   
       if '+cuda' in spec:
-        args.append('-DCUDA_ARCH=sm_{0}'.format(self.spec.variants['cuda_arch'].value[0]))
+        args.append('-DCUDA_ARCH=sm_{0}'.format(self.spec.variants['cuda_arch'].value))
         args.append('-DGT_ENABLE_BACKEND_CUDA=ON')
         args.append('-DGT_ENABLE_BACKEND_X86=OFF')
       else:


### PR DESCRIPTION
Remove the CudaPackage option for gridtools and dycore since it makes testing impossible.