### PR TITLE
specify url to detect remote versions of cosmo

### DIFF
--- a/packages/cosmo/package.py
+++ b/packages/cosmo/package.py
@@ -11,7 +11,7 @@ class Cosmo(MakefilePackage):
     """COSMO: Numerical Weather Prediction Model. Needs access to private GitHub."""
 
     homepage = "http://www.cosmo-model.org"
-    url      = "https://github.com/COSMO-ORG/cosmo/archive/5.06.tar.gz" 
+    url      = "https://github.com/MeteoSwiss-APN/cosmo/archive/5.07.mch1.0.p5.tar.gz"
     git      = 'git@github.com:COSMO-ORG/cosmo.git'
     maintainers = ['elsagermann']
 


### PR DESCRIPTION
This is in order to be able to get and build releases of MeteoSwiss-APN even if they are not specified as versions of the package. 

You can test it with 
```spack versions cosmo
==> Safe versions (already checksummed):
  master          5.07.mch1.0.p3  5.06   5.05
  5.07.mch1.0.p4  5.07.mch1.0.p2  5.05a  mch
==> Remote versions (not yet checksummed):
  5.07.mch1.0.p5
```
right now, you wont see any remote version, because all of the auto-detected versions are also specified as safe versions. 
However if you remove 
https://github.com/MeteoSwiss-APN/spack-mch/blob/6f24ed493c632c02863fc1ddb713345792e41671/packages/cosmo/package.py#L20

you will see that 5.07.mch1.0.p5 is still auto detected. 
I think this is essential for building new releases with jenkins without having to push into master of spack-mch
