### PR TITLE
Some changes to extract the COSMO env for OSM

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
     stages {
         stage('Build') {
             steps {
-                    sh 'GITHUB_COMMENT="' + GITHUB_COMMENT + '" ./jenkins_build.sh'
+                    sh 'GITHUB_COMMENT="' + GITHUB_COMMENT + '" ./tools/jenkins_build.sh'
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Tell the script the machine you are working on using -m <machine> and where you 
 ```bash
 git clone git@github.com:MeteoSwiss-APN/spack-mch.git
 cd spack-mch
-./config.py -m <machine> -i <spack-installation-directory> -v <version> -r <repos.yaml-installation-directory> -p <spack packages, modules & stages installation-directory> -u <ON or OFF, install upstreams.yaml>
+./tools/config.py -m <machine> -i <spack-installation-directory> -v <version> -r <repos.yaml-installation-directory> -p <spack packages, modules & stages installation-directory> -u <ON or OFF, install upstreams.yaml>
 ```
 
 The -r option usually needs to point to the **site scope** of your newly installed spack-instance, that is, _$SPACK_DIR/etc/spack_. It can however also be used if you are a CSCS user and do not want to have your own spack instance *but still want to develop the mch-packages*. In that case, you can clone the spack-mch repo, let the -i, -m options void, BUT overwrite the *site scoped* repos.yaml files of the maintained spack instances by installing a new repos.yaml in your **user scope** _~/.spack_.
@@ -100,7 +100,7 @@ Ex:
 spack install cosmo@master%pgi cosmo_target=gpu
 ```
 
-This will clone the package, build it and install the chosen package plus all its dependencies under _/scratch/$USER/spack/install/tsa_ (see _config.yaml_ in the maching specific config file section for details). The build-stage of your package and its dependencies are not kept (add _--keep-stage_ after the install command in order to keep it). Module files are also created during this process and installed under _/scratch/$USER/spack/modules/_
+This will clone the package, build it and install the chosen package plus all its dependencies under _/scratch/$USER/spack/spack-install/'machine'_ (see _config.yaml_ in the maching specific config file section for details). The build-stage of your package and its dependencies are not kept (add _--keep-stage_ after the install command in order to keep it). Module files are also created during this process and installed under _/scratch/$USER/spack/modules/'machine'/'architecture'/_
 
 You might want to run tests after the installation of your package. In that case you can use:
 
@@ -117,13 +117,13 @@ Submits the adequate testsuites for cosmo-dycore or cosmo after their installati
 If you want to submit your **tests manually** or after the installation, you first have to use the module of your package dependencies
 
 ```bash
-module use /project/g110/spack-modules/'architecture'
+module use /project/g110/modules/admin-'machine'/'architecture'
 ```
 
 and then load your package module:
 
 ```bash
-module load _/scratch/$USER/spack/modules/'architecture'/<package>/<version>-<hash>_
+module load /scratch/$USER/spack/modules/'machine'/'architecture'/<package>/<version>-<hash>
 ```
 
 ## Developer guide
@@ -139,7 +139,7 @@ spack dev-build <package>@<version>%<compiler> +<variants>
 
 If you do not want to git clone the source of the package you want to install, especially if you are developing, you can use a local source in order to install your package. In order to do so, first go to the base directory of the package and then use spack _dev-build_ instead of spack install.
 
-The package, its dependencies and its modules will be still installed under _/scratch/$USER/spack/install_ & _/scratch/$USER/spack/modules/_
+The package, its dependencies and its modules will be still installed under _/scratch/$USER/spack/spack-install_ & _/scratch/$USER/spack/modules/'machine'/'architecture'_
 Notice that once installed, the package will not be rebuilt at the next attempt to _spack dev-build_, even if the sources of the local directory have changed.
 In order to force spack to build the local developments anytime, you need to avoid the installation phase
 

--- a/packages/cosmo/package.py
+++ b/packages/cosmo/package.py
@@ -112,11 +112,15 @@ class Cosmo(MakefilePackage):
             spack_env.set('CLAWXMODSPOOL', self.spec['omni-xmod-pool'].prefix + '/omniXmodPool/')
             if self.spec['mpi'].name == 'mpich':
                 spack_env.append_flags('CLAWFC_FLAGS', '-U__CRAYXC')
-        spack_env.set('UCX_MEMTYPE_CACHE', 'n')
+        
+        run_env_variables = {}
+        run_env_variables['UCX_MEMTYPE_CACHE'] = 'n'
         if '+cppdycore' in self.spec and self.spec.variants['cosmo_target'].value == 'gpu':
-          spack_env.set('UCX_TLS', 'rc_x,ud_x,mm,shm,cuda_copy,cuda_ipc,cma')
+            run_env_variables['UCX_TLS'] = 'rc_x,ud_x,mm,shm,cuda_copy,cuda_ipc,cma'
         else:
-          spack_env.set('UCX_TLS', 'rc_x,ud_x,mm,shm,cma')
+            run_env_variables['UCX_TLS'] = 'rc_x,ud_x,mm,shm,cma'
+        for key in run_env_variables:
+          spack_env.append_flags('SPACK_RUN_ENV' , key + '=' + run_env_variables[key]) 
 
     @property
     def build_targets(self):

--- a/packages/cosmo/package.py
+++ b/packages/cosmo/package.py
@@ -120,6 +120,7 @@ class Cosmo(MakefilePackage):
         else:
             run_env_variables['UCX_TLS'] = 'rc_x,ud_x,mm,shm,cma'
         for key in run_env_variables:
+          spack_env.set(key, run_env_variables[key])
           spack_env.append_flags('SPACK_RUN_ENV' , key + '=' + run_env_variables[key]) 
 
     @property

--- a/sysconfigs/tsa/packages.yaml
+++ b/sysconfigs/tsa/packages.yaml
@@ -19,17 +19,17 @@ packages:
     target: []
     providers: {}
   openmpi:
-    paths:
-      openmpi@4.0.2%pgi: /apps/arolla/UES/jenkins/RH7.6/pgi/19.9/easybuild/software/OpenMPI/4.0.2-PGI-19.9-GCC-8.3.0-cuda-10.1
-      openmpi@4.0.2%gcc: /apps/arolla/UES/jenkins/RH7.6/gnu/19.2/easybuild/software/OpenMPI/4.0.2-gcccuda-2019b-cuda-10.1
+    modules:
+      openmpi@4.0.2%pgi: /apps/arolla/UES/jenkins/RH7.6/pgi/19.9/easybuild/modules/all/openmpi/4.0.2-pgi-19.9-gcc-8.3.0-cuda-10.1
+      openmpi@4.0.2%gcc: /apps/arolla/UES/jenkins/RH7.6/gnu/19.2/easybuild/modules/all/openmpi/4.0.2-gcccuda-2019b-cuda-10.1
   netcdf-fortran:
-    paths:
-      netcdf-fortran@4.4.5%pgi +mpi: /apps/arolla/UES/jenkins/RH7.6/pgi/19.9/easybuild/software/netCDF-Fortran/4.4.5-PGI-19.9-GCC-8.3.0/
-      netcdf-fortran@4.4.5%gcc +mpi: /apps/arolla/UES/jenkins/RH7.6/gnu/19.2/easybuild/software/netCDF-Fortran/4.4.5-fosscuda-2019b
+    modules:
+      netcdf-fortran@4.4.5%pgi +mpi: /apps/arolla/UES/jenkins/RH7.6/pgi/19.9/easybuild/modules/all/netcdf-fortran/4.4.5-pgi-19.9-gcc-8.3.0
+      netcdf-fortran@4.4.5%gcc +mpi: /apps/arolla/UES/jenkins/RH7.6/gnu/19.2/easybuild/modules/all/netcdf-fortran/4.4.5-fosscuda-2019b
   netcdf-c:
-    paths:
-      netcdf-c@4.7.0%pgi +mpi: /apps/arolla/UES/jenkins/RH7.6/pgi/19.9/easybuild/software/netCDF/4.7.0-PGI-19.9-GCC-8.3.0
-      netcdf-c@4.7.0%gcc +mpi: /apps/arolla/UES/jenkins/RH7.6/gnu/19.2/easybuild/software/netCDF/4.7.0-fosscuda-2019b
+    modules:
+      netcdf-c@4.7.0%pgi +mpi: /apps/arolla/UES/jenkins/RH7.6/pgi/19.9/easybuild/modules/all/netcdf/4.7.0-pgi-19.9-gcc-8.3.0
+      netcdf-c@4.7.0%gcc +mpi: /apps/arolla/UES/jenkins/RH7.6/gnu/19.2/easybuild/modules/all/netcdf/4.7.0-fosscuda-2019b
   perl:
     paths: 
       perl@5.16.3: /usr

--- a/sysconfigs/tsa_rh7.7/packages.yaml
+++ b/sysconfigs/tsa_rh7.7/packages.yaml
@@ -19,17 +19,17 @@ packages:
     target: []
     providers: {}
   openmpi:
-    paths:
-      openmpi@4.0.2%pgi: /apps/arolla/UES/jenkins/RH7.7/pgi/19.9/easybuild/software/OpenMPI/4.0.2-PGI-19.9-GCC-8.3.0-cuda-10.1
-      openmpi@4.0.2%gcc: /apps/arolla/UES/jenkins/RH7.7/gnu/19.2/easybuild/software/OpenMPI/4.0.2-gcccuda-2019b-cuda-10.1
+    modules:
+      openmpi@4.0.2%pgi: /apps/arolla/UES/jenkins/RH7.7/pgi/19.9/easybuild/modules/all/openmpi/4.0.2-pgi-19.9-gcc-8.3.0-cuda-10.1
+      openmpi@4.0.2%gcc: /apps/arolla/UES/jenkins/RH7.7/gnu/19.2/easybuild/modules/all/openmpi/4.0.2-gcccuda-2019b-cuda-10.1
   netcdf-fortran:
     modules:
-      netcdf-fortran@4.4.5%gcc +mpi: /apps/arolla/UES/jenkins/RH7.7/gnu/19.2/easybuild/modules/all/netcdf-fortran/4.4.5-fosscuda-2019b
       netcdf-fortran@4.4.5%pgi +mpi: /apps/arolla/UES/jenkins/RH7.7/pgi/19.9/easybuild/modules/all/netcdf-fortran/4.4.5-pgi-19.9-gcc-8.3.0
+      netcdf-fortran@4.4.5%gcc +mpi: /apps/arolla/UES/jenkins/RH7.7/gnu/19.2/easybuild/modules/all/netcdf-fortran/4.4.5-fosscuda-2019b
   netcdf-c:
     modules:
-      netcdf-c@4.7.0%gcc +mpi: /apps/arolla/UES/jenkins/RH7.7/gnu/19.2/easybuild/modules/all/netcdf/4.7.0-fosscuda-2019b
       netcdf-c@4.7.0%pgi +mpi: /apps/arolla/UES/jenkins/RH7.7/pgi/19.9/easybuild/modules/all/netcdf/4.7.0-pgi-19.9-gcc-8.3.0
+      netcdf-c@4.7.0%gcc +mpi: /apps/arolla/UES/jenkins/RH7.7/gnu/19.2/easybuild/modules/all/netcdf/4.7.0-fosscuda-2019b
   perl:
     paths: 
       perl@5.16.3: /usr

--- a/tools/config.py
+++ b/tools/config.py
@@ -37,7 +37,7 @@ def main():
     if args.reposdir:
         if os.path.isdir(args.reposdir) and not os.path.isfile(args.reposdir + '/repos.yaml'):
             repos_data = yaml.safe_load(open(dir_path + '/../sysconfigs/repos.yaml', 'r'))
-            repos_data['repos'] = [dir_path]
+            repos_data['repos'] = [dir_path + '/../']
             yaml.safe_dump(repos_data, open(dir_path + '/../sysconfigs/repos.yaml', 'w'), default_flow_style=False)
             print('Installing repos.yaml on ' + args.reposdir)
             os.popen('cp ' + dir_path + '/../sysconfigs/repos.yaml ' + args.reposdir)

--- a/tools/config.py
+++ b/tools/config.py
@@ -36,14 +36,14 @@ def main():
 
     if args.reposdir:
         if os.path.isdir(args.reposdir) and not os.path.isfile(args.reposdir + '/repos.yaml'):
-            repos_data = yaml.safe_load(open('./sysconfigs/repos.yaml', 'r'))
+            repos_data = yaml.safe_load(open(dir_path + '/../sysconfigs/repos.yaml', 'r'))
             repos_data['repos'] = [dir_path]
-            yaml.safe_dump(repos_data, open('./sysconfigs/repos.yaml', 'w'), default_flow_style=False)
+            yaml.safe_dump(repos_data, open(dir_path + '/../sysconfigs/repos.yaml', 'w'), default_flow_style=False)
             print('Installing repos.yaml on ' + args.reposdir)
-            os.popen('cp ' + dir_path + '/sysconfigs/repos.yaml ' + args.reposdir)
+            os.popen('cp ' + dir_path + '/../sysconfigs/repos.yaml ' + args.reposdir)
 
     # configure config.yaml
-    config_data = yaml.safe_load(open('sysconfigs/config.yaml', 'r'))
+    config_data = yaml.safe_load(open(dir_path + '/../sysconfigs/config.yaml', 'r'))
 
     if not args.pckgidir:
         if 'admin' in args.machine:
@@ -56,20 +56,20 @@ def main():
     config_data['config']['install_tree'] = args.pckgidir + '/spack-install/' + args.machine.replace('admin-', '')
     config_data['config']['build_stage'] = [args.pckgidir + '/spack-stages/' + args.machine.replace('admin-', '')]
     config_data['config']['module_roots']['tcl'] = args.pckgidir + '/modules/' + args.machine
-    yaml.safe_dump(config_data, open('./sysconfigs/config.yaml', 'w'), default_flow_style=False)
+    yaml.safe_dump(config_data, open(dir_path + '/../sysconfigs/config.yaml', 'w'), default_flow_style=False)
 
     # copy modified config.yaml file in site scope of spack instance
-    os.popen('cp -rf sysconfigs/config.yaml ' + args.idir + '/spack/etc/spack')
+    os.popen('cp -rf ' + dir_path + '/../sysconfigs/config.yaml ' + args.idir + '/spack/etc/spack')
 
     # copy modified upstreams.yaml if not admin
     if not 'admin' in args.machine and args.upstreams=='ON':
-        upstreams_data = yaml.safe_load(open('./sysconfigs/upstreams.yaml', 'r'))
+        upstreams_data = yaml.safe_load(open(dir_path + '/../sysconfigs/upstreams.yaml', 'r'))
         upstreams_data['upstreams']['spack-instance-1']['install_tree'] = '/project/g110/spack-install/' + args.machine.replace('admin-', '')
-        yaml.safe_dump(upstreams_data, open('./sysconfigs/upstreams.yaml', 'w'), default_flow_style=False)
-        os.popen('cp -rf sysconfigs/upstreams.yaml ' + args.idir + '/spack/etc/spack')
+        yaml.safe_dump(upstreams_data, open(dir_path + '/../sysconfigs/upstreams.yaml', 'w'), default_flow_style=False)
+        os.popen('cp -rf ' + dir_path +'/../sysconfigs/upstreams.yaml ' + args.idir + '/spack/etc/spack')
 
     # copy modules.yaml, packages.yaml and compiles.yaml files in site scope of spack instance
-    os.popen('cp -rf sysconfigs/' + args.machine.replace('admin-', '') + '/* ' +  args.idir + '/spack/etc/spack')
+    os.popen('cp -rf ' + dir_path + '/../sysconfigs/' + args.machine.replace('admin-', '') + '/* ' +  args.idir + '/spack/etc/spack')
 
     print('MCH Spack installed.')
 

--- a/tools/extract_env.sh
+++ b/tools/extract_env.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+TEMP=$@
+eval set -- "$TEMP --"
+while true; do
+    case "$1" in
+        --env_dir|-e) env_dir=$2; shift 2;;
+        --help|-h) help_enabled=yes; fwd_args="$fwd_args $1"; shift;;
+        -- ) shift; break ;;
+        * ) fwd_args="$fwd_args $1"; shift ;;
+    esac
+done
+
+if [[ "${help_enabled}" == "yes" ]]; then
+    echo "Available Options:"
+    echo "* --env_dir.  |-e {spack-build-env.txt directory} The directory where spack-build-env.txt is located, Default: \$(pwd)"
+    echo "* --help.  |-h {print help}"
+    exit 0
+fi
+
+touch env.txt
+
+eval `grep -rw $env_dir/spack-build-env.txt -e LOADEDMODULES`
+eval `grep -rw $env_dir/spack-build-env.txt -e SPACK_RUN_ENV`
+
+IFS=':' read -r -a module_array <<< "$LOADEDMODULES"
+for module in ${module_array[@]}; do
+    echo "module load $module" >> env.txt
+done
+
+for item in ${SPACK_RUN_ENV[@]}; do
+      echo $item >> env.txt
+done

--- a/tools/extract_env.sh
+++ b/tools/extract_env.sh
@@ -29,5 +29,5 @@ for module in ${module_array[@]}; do
 done
 
 for item in ${SPACK_RUN_ENV[@]}; do
-      echo $item >> env.txt
+      echo "export $item" >> env.txt
 done

--- a/tools/jenkins_build.sh
+++ b/tools/jenkins_build.sh
@@ -2,7 +2,7 @@ echo ${GITHUB_COMMENT}
 spec=${GITHUB_COMMENT#"launch jenkins "}
 
 # install spack temp instance with branch config files and mch spack packages
-./config.py -m tsa -i . -r ./spack/etc/spack -p $PWD/spack -u OFF
+./tools/config.py -m tsa -i . -r ./spack/etc/spack -p $PWD/spack -u OFF
 
 # source spack instance
 . spack/share/spack/setup-env.sh


### PR DESCRIPTION
CHANGES:

- ADD: dictionary run_env_variables, which stores the variables needed at runtime and sets a new env variable SPACK_RUN_ENV, from which we can extract those variables after compilation.
- ADD: extract_env.sh a bash script which takes the directory of a spack-build-env.txt file, extract the variables LOADEDMODULES and SPACK_RUN_ENV and create an env.txt file with the correct list of modules and run time variables. env.txt can be directly sourced by OSM.
- ADD: Folder tools which now contains config.py and extract_env.txt and soon the build scripts used by the Jenkinsfile.
- FIX: config.py in order to be used in its new location and called from every possible folder.