### PR TITLE
Add a new version dev-build, for dev-build compilation

### DIFF
--- a/packages/cosmo/package.py
+++ b/packages/cosmo/package.py
@@ -16,6 +16,7 @@ class Cosmo(MakefilePackage):
     maintainers = ['elsagermann']
 
     version('master', branch='master')
+    version('dev-build', branch='master')
     version('mch', git='git@github.com:MeteoSwiss-APN/cosmo.git', branch='mch')
     version('5.07.mch1.0.p5', git='git@github.com:MeteoSwiss-APN/cosmo.git', tag='5.07.mch1.0.p5')
     version('5.07.mch1.0.p4', git='git@github.com:MeteoSwiss-APN/cosmo.git', tag='5.07.mch1.0.p4')


### PR DESCRIPTION
Avoid the problem that master may be installed in the upstream.
Usage : spack dev-build --until build cosmo@dev-build%pgi cosmo_target=cpu -cppdycore