### PR TITLE
ADD: extract_env python script

### DIFF
--- a/packages/cosmo/package.py
+++ b/packages/cosmo/package.py
@@ -143,6 +143,16 @@ class Cosmo(MakefilePackage):
         else:
           spack_env.set('UCX_TLS', 'rc_x,ud_x,mm,shm,cma')
 
+        run_env_variables = {}
+        run_env_variables['UCX_MEMTYPE_CACHE'] = 'n'
+        if '+cppdycore' in self.spec and self.spec.variants['cosmo_target'].value == 'gpu':
+            run_env_variables['UCX_TLS'] = 'rc_x,ud_x,mm,shm,cuda_copy,cuda_ipc,cma'
+        else:
+            run_env_variables['UCX_TLS'] = 'rc_x,ud_x,mm,shm,cma'
+        for key in run_env_variables:
+            spack_env.set(key, run_env_variables[key])
+        spack_env.set('SPACK_RUN_ENV' , run_env_variables)
+
     @property
     def build_targets(self):
         build = []

--- a/tools/extract_env.py
+++ b/tools/extract_env.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env spack-python
+
+import sys
+import os
+import ast
+
+from spack.spec import Spec
+import spack.build_environment as build_environment
+
+def main():  
+    spack_spec = Spec(' '.join(sys.argv[1:]))
+    spack_spec.concretize()
+
+    build_environment.setup_package(spack_spec.package, False)
+    
+    env_file = open("env.txt","w+")
+
+    module_list = os.environ['LOADEDMODULES'].split(':')
+
+    for module in module_list:
+        env_file.write('module load ' + module + '\n')
+
+    run_env_variables = {}
+    try: 
+        run_env_variables = ast.literal_eval(os.environ['SPACK_RUN_ENV'])
+        for key in run_env_variables:
+            env_file.write('export ' + key + '=' + run_env_variables[key] + '\n')
+    except:
+        print('Warning: missing SPACK_RUN_ENV variable for this package')
+
+    env_file.close()
+
+if __name__ == "__main__":
+      main()


### PR DESCRIPTION
Thought it would be much better to do a python script actually taking directly a spack spec as argument extracting the SPACK_RUN_ENV dictionary and creating the env.txt directly so this PR changes that.

To test just:

./extract_env.py <spec>