### PR TITLE
Disable MPI for eckit

### DIFF
--- a/packages/eckit/package.py
+++ b/packages/eckit/package.py
@@ -12,8 +12,8 @@ class Eckit(CMakePackage):
     of tools and applications at ECMWF"""
 
     homepage = 'https://software.ecmwf.int/wiki/display/ECKIT'
-    url      = "https://github.com/ecmwf/eckit/archive/1.10.1.tar.gz"
-    git      = 'https://github.com/ecmwf/eckit.git'
+    url = "https://github.com/ecmwf/eckit/archive/1.10.1.tar.gz"
+    git = 'https://github.com/ecmwf/eckit.git'
     maintainers = ['cosunae']
 
     version('master', branch='master')
@@ -26,6 +26,6 @@ class Eckit(CMakePackage):
 
         args.append('-DCMAKE_MODULE_PATH={0}/share/ecbuild/cmake'.
                     format(spec['ecbuild'].prefix))
+        args.append('-DENABLE_MPI=OFF')
 
         return args
-


### PR DESCRIPTION
## Technical Description

MPI was causing problems using `srun` on tsa:

```
Attempting to access a non-existent instance of Main()
backtrace [1] stack has 33 addresses
(/scratch/mroeth/spack/spack-install/tsa/eckit/develop/gcc/merl734gm2qdzjxyzousc65ihabhthzv/lib/libeckit.so+eckit::BackTrace::dump[abi:cxx11]())0x18e 
(/scratch/mroeth/spack/spack-install/tsa/eckit/develop/gcc/merl734gm2qdzjxyzousc65ihabhthzv/lib/libeckit.so+eckit::Main::instance())0x41 
(/scratch/mroeth/spack/spack-install/tsa/eckit/develop/gcc/merl734gm2qdzjxyzousc65ihabhthzv/lib/libeckit.so+)0x12633b 
``` 

Furthermore, a lot of our utilities are not even designed to work with MPI (mesh generation, mesh import from netcdf), so I reckon it's better to disable MPI explicitly. 
