### PR TITLE
FIX: gnu compiler for cuda and slurm

### DIFF
--- a/packages/cosmo-dycore/package.py
+++ b/packages/cosmo-dycore/package.py
@@ -64,9 +64,9 @@ class CosmoDycore(CMakePackage):
     depends_on('boost@1.67.0')
     depends_on('serialbox@2.6.0', when='+build_tests')
     depends_on('mpi', type=('build', 'run'))
-    depends_on('slurm', type='run')
+    depends_on('slurm%gcc', type='run')
     depends_on('cmake@3.12:%gcc', type='build')
-    depends_on('cuda', when='+cuda', type=('build', 'run'))
+    depends_on('cuda%gcc', when='+cuda', type=('build', 'run'))
 
     conflicts('+production', when='build_type=Debug')
     conflicts('+production', when='cosmo_target=cpu')

--- a/packages/cosmo/package.py
+++ b/packages/cosmo/package.py
@@ -58,10 +58,10 @@ class Cosmo(MakefilePackage):
 
     dycore_deps(apngit)
 
-    depends_on('netcdf-fortran')
-    depends_on('netcdf-c')
-    depends_on('slurm', type='run')
-    depends_on('cuda', when='cosmo_target=gpu', type=('build', 'run'))
+    depends_on('netcdf-fortran +mpi')
+    depends_on('netcdf-c +mpi')
+    depends_on('slurm%gcc', type='run')
+    depends_on('cuda%gcc', when='cosmo_target=gpu', type=('build', 'run'))
     depends_on('serialbox@2.6.0', when='+serialize')
     depends_on('mpi', type=('build', 'run'))
     depends_on('libgrib1')

--- a/sysconfigs/daint/packages.yaml
+++ b/sysconfigs/daint/packages.yaml
@@ -61,8 +61,8 @@ packages:
             cray-libsci_acc@19.10.1%pgi:   cray-libsci_acc/19.10.1
     cuda:
         modules:
-          cuda@10.0: cudatoolkit/10.0.130_3.22-7.0.1.0_5.2__gdfb4ce5
-          cuda@10.1: cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7
+          cuda@10.0%gcc: cudatoolkit/10.0.130_3.22-7.0.1.0_5.2__gdfb4ce5
+          cuda@10.1%gcc: cudatoolkit/10.1.105_3.27-7.0.1.1_4.1__ga311ce7
         version: ['10.1']
     curl:
         paths:
@@ -222,7 +222,7 @@ packages:
             readline@7.0: /usr
     slurm:
       modules:
-        slurm@19.05.3-2: slurm/19.05.3-2
+        slurm@19.05.3-2%gcc: slurm/19.05.3-2
     tar:
         paths:
              tar@1.30.0: /bin

--- a/sysconfigs/tsa/packages.yaml
+++ b/sysconfigs/tsa/packages.yaml
@@ -13,7 +13,7 @@ packages:
     paths: {}
   cuda:
     modules:
-      cuda@10.1.243: cuda/10.1.243
+      cuda@10.1.243%gcc: cuda/10.1.243
     buildable: true
     version: []
     target: []
@@ -65,7 +65,7 @@ packages:
       bzip2@1.0.6: /usr
   slurm:
     modules:
-      slurm@19.05.05: slurm/19.05.05
+      slurm@19.05.05%gcc: slurm/19.05.05
   int2lm:
     variants: slave=tsa
   libgrib1:


### PR DESCRIPTION
This makes sure that cosmo%pgi will take the right dycore if the corresponding dycore is installed with ^openmpi%pgi