### PR TITLE
Devbuildcosmo

### DIFF
--- a/config.py
+++ b/config.py
@@ -6,14 +6,14 @@ import yaml
 import shutil
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
-spack_version='v0.15.0'
+spack_version='v0.15.3'
 
 def main():
     parser=argparse.ArgumentParser(description='Small config script which can be used to install a spack instance with the correct configuration files and mch spack packages.')
     parser.add_argument('-i', '--idir', type=str, default=dir_path, help='Where the Spack instance is installed or you want it to be installed')
     parser.add_argument('-m', '--machine', type=str, help='Required: machine name')
     parser.add_argument('-u', '--upstreams', type=str, default='ON', help='ON or OFF, install upstreams.yaml file')
-    parser.add_argument('-v', '--version', type=str, default='v0.14.2', help='Spack version, Default: ' + spack_version)
+    parser.add_argument('-v', '--version', type=str, default=spack_version, help='Spack version, Default: ' + spack_version)
     parser.add_argument('-r', '--reposdir', type=str, help='repos.yaml install directory')
     parser.add_argument('-p', '--pckgidir', type=str, help='Define spack package, modules & stages installation directory. Default: tsa; /scratch/$USER/spack, daint; /scratch/snx3000/$USER/spack')
     args=parser.parse_args()

--- a/tools/spack-scripting/scripting/cmd/devbuildcosmo.py
+++ b/tools/spack-scripting/scripting/cmd/devbuildcosmo.py
@@ -23,48 +23,21 @@ description = "Dev-build cosmo and dycore with or without testing."
 section = "scripting"
 level = "long"
 
-
 def setup_parser(subparser):
-    arguments.add_common_arguments(subparser, ['jobs'])
-    subparser.add_argument(
-        '-d', '--source-path', dest='source_path', default=None,
-        help="path to source directory. defaults to the current directory")
-    subparser.add_argument(
-        '-i', '--ignore-dependencies', action='store_true', dest='ignore_deps',
-        help="don't try to install dependencies of requested packages")
-    arguments.add_common_arguments(subparser, ['no_checksum'])
-    subparser.add_argument(
-        '--keep-prefix', action='store_true',
-        help="do not remove the install prefix if installation fails")
-    subparser.add_argument(
-        '--skip-patch', action='store_true',
-        help="skip patching for the developer build")
-    subparser.add_argument(
-        '-q', '--quiet', action='store_true', dest='quiet',
-        help="do not display verbose build output while installing")
-    subparser.add_argument(
-        '--drop-in', type=str, dest='shell', default=None,
-        help="drop into a build environment in a new shell, e.g. bash, zsh")
-
     subparser.add_argument(
         '-t', '--test', action='store_true', help="Dev-build with testing")
     subparser.add_argument(
         '-c', '--clean_build', action='store_true', help="Clean dev-build")
-    subparser.add_argument(
-        '-w', '--without_dycore', action='store_true', help="Dev-build cosmo but not dycore")
-
     arguments.add_common_arguments(subparser, ['spec'])
 
-    stop_group = subparser.add_mutually_exclusive_group()
-    stop_group.add_argument(
-        '-b', '--before', type=str, dest='before', default=None,
-        help="phase to stop before when installing (default None)")
-    stop_group.add_argument(
-        '-u', '--until', type=str, dest='until', default=None,
-        help="phase to stop after when installing (default None)")
+def custom_devbuild(source_path, spec):
+    package = spack.repo.get(spec)
+    package.stage = DIYStage(source_path)
 
-    cd_group = subparser.add_mutually_exclusive_group()
-    arguments.add_common_arguments(cd_group, ['clean', 'dirty'])
+    if package.installed:
+        package.do_uninstall()
+        
+    package.do_install(verbose=True)
 
 
 def devbuildcosmo(self, args):
@@ -77,62 +50,52 @@ def devbuildcosmo(self, args):
         tty.die("spack dev-build only takes one spec.")
 
     cosmo_spec = specs[0]
-    temp_cosmo_spec = str(cosmo_spec)
     cosmo_spec.concretize()
 
     # Set dycore_spec
-    if not args.without_dycore:
-        dycore_spec = 'cosmo-dycore@dev-build'
-    else:
-        dycore_spec = 'cosmo-dycore@master'
-    dycore_spec += ' real_type=' + cosmo_spec.variants['real_type'].value
-    dycore_spec += ' ^' + cosmo_spec.format('{^mpi.name}') + '%' + cosmo_spec.compiler.name
+    dycore_spec = 'cosmo-dycore@dev-build'
 
-    base_directory = os.getcwd()
+    # Extracting dycore variants
+    dycore_spec += cosmo_spec.format('{^cosmo-dycore.variants}')
+
+    # Extracting correct mpi variant
+    dycore_spec += ' ^' + cosmo_spec.format('{^mpicuda.name}') + '%' + cosmo_spec.compiler.name + cosmo_spec.format('{^mpicuda.variants}') 
+    
+    # remove the slurm_args variant causing troubles to the concretizer
+    dycore_spec = dycore_spec.replace(cosmo_spec.format('{^cosmo-dycore.variants.slurm_args}'), ' ')
+    
+    dycore_spec = Spec(dycore_spec).concretized()
+    
+    # Setting source_path to current working directory
+    source_path = os.getcwd()
+    source_path = os.path.abspath(source_path)
 
     # Clean if needed
     if args.clean_build:
         print('\033[92m' + '==> ' + '\033[0m' + 'cosmo: Cleaning build directory')
-        subprocess.run(["make", "clean"], cwd = base_directory + '/cosmo/ACC')
+        subprocess.run(["make", "clean"], cwd = source_path + '/cosmo/ACC')
 
-        if not args.without_dycore:
-          print('\033[92m' + '==> ' + '\033[0m' + 'dycore: Cleaning build directory')
-          shutil.rmtree(base_directory + '/spack-build')
+        if os.path.exists(base_directory + '/spack-build'):
+            print('\033[92m' + '==> ' + '\033[0m' + 'dycore: Cleaning build directory')
+            shutil.rmtree(source_path + '/spack-build')
 
-    if cosmo_spec.satisfies('+cppdycore') and not args.without_dycore:
-        # Concretize dycore spec and cosmo_serialize spec
-        dycore_spec = Spec(dycore_spec)
-        dycore_spec.concretize()
-
-        args.spec = str(dycore_spec)
-
-        if args.until == 'build':
-            shutil.rmtree(dycore_spec.prefix)
-            args.until = None
-
+    if cosmo_spec.satisfies('+cppdycore'):
         # Dev-build dycore
-        dev_build(self, args)
-        # Launch dycore tests
+        custom_devbuild(source_path, dycore_spec)
+
         if args.test:
             print('\033[92m' + '==> ' + '\033[0m' + 'cosmo-dycore: Launching dycore tests')
-            subprocess.run(['./dycore/test/tools/test_dycore.py', str(dycore_spec), base_directory + '/spack-build'])
-
-        find_cmd = SpackCommand('find')
-        dycore_hash = find_cmd('--format', '{hash}', 'cosmo-dycore@dev-build', 'real_type=' + cosmo_spec.variants['real_type'].value, ' ^' + cosmo_spec.format('{^mpi.name}') + '%' + cosmo_spec.compiler.name)
-
-        temp_cosmo_spec = temp_cosmo_spec + ' ^/' + dycore_hash
-        args.spec = temp_cosmo_spec
-        args.ignore_deps = True
+            subprocess.run(['./dycore/test/tools/test_dycore.py', str(dycore_spec), source_path + '/spack-build'])
 
     # Dev-build cosmo
-    dev_build(self, args)
+    custom_devbuild(source_path, cosmo_spec)
 
     # Launch cosmo tests
-    if args.test and '~serialize' in cosmo_spec:
+    if args.test:
         print('\033[92m' + '==> ' + '\033[0m' + 'cosmo: Launching cosmo tests')
-        subprocess.run(["./cosmo/ACC/test/tools/test_cosmo.py", str(cosmo_spec), base_directory])
+        subprocess.run(["./cosmo/ACC/test/tools/test_cosmo.py", str(cosmo_spec), source_path])
 
     # Serialize data
     if '+serialize' in cosmo_spec:
         print('\033[92m' + '==> ' + '\033[0m' + 'cosmo: Serializing data')
-        subprocess.run(["./cosmo/ACC/test/tools/serialize_cosmo.py", str(cosmo_spec), base_directory])
+        subprocess.run(["./cosmo/ACC/test/tools/serialize_cosmo.py", str(cosmo_spec), source_path])

--- a/tools/spack-scripting/scripting/cmd/devbuildcosmo.py
+++ b/tools/spack-scripting/scripting/cmd/devbuildcosmo.py
@@ -56,10 +56,10 @@ def devbuildcosmo(self, args):
     dycore_spec = 'cosmo-dycore@dev-build'
 
     # Extracting dycore variants
-    dycore_spec += cosmo_spec.format('{^cosmo-dycore.variants}')
+    dycore_spec = cosmo_spec.format('{^cosmo-dycore.name}') + cosmo_spec.format('{^cosmo-dycore.@version}') + cosmo_spec.format('{^cosmo-dycore.%compiler}') + cosmo_spec.format('{^cosmo-dycore.variants}')
 
     # Extracting correct mpi variant
-    dycore_spec += ' ^' + cosmo_spec.format('{^mpi.name}') + '%' + cosmo_spec.compiler.name + cosmo_spec.format('{^mpi.variants}')
+    dycore_spec += ' ^' + cosmo_spec.format('{^mpi.name}') + cosmo_spec.format('{^mpi.@version}') + cosmo_spec.format('{^mpi.%compiler}') + cosmo_spec.format('{^mpi.variants}')
 
     # remove the slurm_args variant causing troubles to the concretizer
     dycore_spec = dycore_spec.replace(cosmo_spec.format('{^cosmo-dycore.variants.slurm_args}'), ' ')

--- a/tools/spack-scripting/scripting/cmd/devbuildcosmo.py
+++ b/tools/spack-scripting/scripting/cmd/devbuildcosmo.py
@@ -43,8 +43,9 @@ def setup_parser(subparser):
         '-q', '--quiet', action='store_true', dest='quiet',
         help="do not display verbose build output while installing")
     subparser.add_argument(
-        '-u', '--until', type=str, dest='until', default=None,
-        help="phase to stop after when installing (default None)")
+        '--drop-in', type=str, dest='shell', default=None,
+        help="drop into a build environment in a new shell, e.g. bash, zsh")
+
     subparser.add_argument(
         '-t', '--test', action='store_true', help="Dev-build with testing")
     subparser.add_argument(
@@ -53,6 +54,14 @@ def setup_parser(subparser):
         '-w', '--without_dycore', action='store_true', help="Dev-build cosmo but not dycore")
 
     arguments.add_common_arguments(subparser, ['spec'])
+
+    stop_group = subparser.add_mutually_exclusive_group()
+    stop_group.add_argument(
+        '-b', '--before', type=str, dest='before', default=None,
+        help="phase to stop before when installing (default None)")
+    stop_group.add_argument(
+        '-u', '--until', type=str, dest='until', default=None,
+        help="phase to stop after when installing (default None)")
 
     cd_group = subparser.add_mutually_exclusive_group()
     arguments.add_common_arguments(cd_group, ['clean', 'dirty'])

--- a/tools/spack-scripting/scripting/cmd/devbuildcosmo.py
+++ b/tools/spack-scripting/scripting/cmd/devbuildcosmo.py
@@ -35,7 +35,7 @@ def custom_devbuild(source_path, spec):
     package.stage = DIYStage(source_path)
 
     if package.installed:
-        package.do_uninstall()
+        package.do_uninstall(force=True)
 
     package.do_install(verbose=True)
 

--- a/tools/spack-scripting/scripting/cmd/devbuildcosmo.py
+++ b/tools/spack-scripting/scripting/cmd/devbuildcosmo.py
@@ -36,7 +36,7 @@ def custom_devbuild(source_path, spec):
 
     if package.installed:
         package.do_uninstall()
-        
+
     package.do_install(verbose=True)
 
 
@@ -59,13 +59,13 @@ def devbuildcosmo(self, args):
     dycore_spec += cosmo_spec.format('{^cosmo-dycore.variants}')
 
     # Extracting correct mpi variant
-    dycore_spec += ' ^' + cosmo_spec.format('{^mpicuda.name}') + '%' + cosmo_spec.compiler.name + cosmo_spec.format('{^mpicuda.variants}') 
-    
+    dycore_spec += ' ^' + cosmo_spec.format('{^mpi.name}') + '%' + cosmo_spec.compiler.name + cosmo_spec.format('{^mpi.variants}')
+
     # remove the slurm_args variant causing troubles to the concretizer
     dycore_spec = dycore_spec.replace(cosmo_spec.format('{^cosmo-dycore.variants.slurm_args}'), ' ')
-    
+
     dycore_spec = Spec(dycore_spec).concretized()
-    
+
     # Setting source_path to current working directory
     source_path = os.getcwd()
     source_path = os.path.abspath(source_path)


### PR DESCRIPTION
Changes for devbuildcosmo as talked on tuesday (see only devbuildcosmo.py, rest is from a previous merge)

- >     not using the dev-build parser anymore but a custom one only taking --clean or --test and the spec as args
- >     cleaning or testing cosmo && dycore but not one only
- >     always desinstalling before reinstalling (BOTH packages

