### PR TITLE
Add CLAW runtime dependency on Fortran compiler

### DIFF
--- a/packages/cce/package.py
+++ b/packages/cce/package.py
@@ -1,0 +1,12 @@
+from spack import *
+
+
+class Cce(Package):
+    """Cray compiler
+
+    Note: This package cannot be installed, it wraps existing installation, specified 
+    in packages.yaml.
+    """
+
+    version('10.0.2', sha256='none', url='http://fake-link.tgz')
+

--- a/packages/cce/package.py
+++ b/packages/cce/package.py
@@ -7,6 +7,7 @@ class Cce(Package):
     Note: This package cannot be installed, it wraps existing installation, specified 
     in packages.yaml.
     """
-
+    
+    homepage = "https://user.cscs.ch/computing/compilation/cray/"
     version('10.0.2', sha256='none', url='http://fake-link.tgz')
 

--- a/packages/intel/package.py
+++ b/packages/intel/package.py
@@ -1,6 +1,6 @@
 from spack import *
 
-class Intel(IntelPackage):
+class Intel(Package):
     """Intel Compilers.
        Note: This package cannot be installed, it wraps existing installation, specified 
        in packages.yaml.

--- a/packages/intel/package.py
+++ b/packages/intel/package.py
@@ -1,0 +1,16 @@
+from spack import *
+
+class Intel(IntelPackage):
+    """Intel Compilers.
+       Note: This package cannot be installed, it wraps existing installation, specified 
+       in packages.yaml.
+    """
+
+    homepage = "https://software.intel.com/en-us/intel-parallel-studio-xe"
+
+    # Same as in ../intel-parallel-studio/package.py, Composer Edition,
+    # but the version numbering in Spack differs.
+    version('19.0.1.144', sha256='none', url='http://fake-link.tgz')
+    version('19.1.1.217', sha256='none', url='http://fake-link.tgz')
+
+

--- a/packages/intel/package.py
+++ b/packages/intel/package.py
@@ -8,8 +8,6 @@ class Intel(IntelPackage):
 
     homepage = "https://software.intel.com/en-us/intel-parallel-studio-xe"
 
-    # Same as in ../intel-parallel-studio/package.py, Composer Edition,
-    # but the version numbering in Spack differs.
     version('19.0.1.144', sha256='none', url='http://fake-link.tgz')
     version('19.1.1.217', sha256='none', url='http://fake-link.tgz')
 

--- a/packages/pgi/package.py
+++ b/packages/pgi/package.py
@@ -1,0 +1,13 @@
+from spack import *
+from spack.pkg.builtin.pgi import Pgi as SpackPgi
+
+class Pgi(SpackPgi):
+    """PGI optimizing multi-core x64 compilers for Linux, MacOS & Windows
+    with support for debugging and profiling of local MPI processes.
+
+    Note: This package cannot be installed, it can only wrap existing installations specified 
+    in packages.yaml.
+    """
+
+    version('20.1.0', sha256='none')
+    version('20.1.1', sha256='none')

--- a/packages/pgi/package.py
+++ b/packages/pgi/package.py
@@ -1,13 +1,44 @@
 from spack import *
-from spack.pkg.builtin.pgi import Pgi as SpackPgi
+from spack.util.prefix import Prefix
+import os
 
-class Pgi(SpackPgi):
+class Pgi(Package):
     """PGI optimizing multi-core x64 compilers for Linux, MacOS & Windows
     with support for debugging and profiling of local MPI processes.
 
-    Note: This package cannot be installed, it can only wrap existing installations specified 
+    Note: This package cannot be installed, it wraps existing installation, specified 
     in packages.yaml.
     """
+    homepage = "http://www.pgroup.com/"
 
-    version('20.1.0', sha256='none')
-    version('20.1.1', sha256='none')
+    version('20.1', sha256='none')
+    version('19.9', sha256='none')
+
+    # Licensing
+    license_required = True
+    license_comment = '#'
+    license_files = ['license.dat']
+    license_vars = ['PGROUPD_LICENSE_FILE', 'LM_LICENSE_FILE']
+    license_url = 'http://www.pgroup.com/doc/pgiinstall.pdf'
+    
+    def url_for_version(self, version):
+        if int(str(version.up_to(1))) <= 17:
+            return "file://{0}/pgilinux-20{1}-{2}-x86_64.tar.gz".format(
+                os.getcwd(), version.up_to(1), version.joined)
+        else:
+            return "file://{0}/pgilinux-20{1}-{2}-x86-64.tar.gz".format(
+                os.getcwd(), version.up_to(1), version.joined)
+
+    def install(self, spec, prefix):
+        pass
+
+    def setup_run_environment(self, env):
+        prefix = Prefix(join_path(self.prefix, 'linux86-64', self.version))
+
+        env.prepend_path('PATH', prefix.bin)
+        env.prepend_path('MANPATH', prefix.man)
+        env.prepend_path('LD_LIBRARY_PATH', prefix.lib)
+        env.set('CC',  join_path(prefix.bin, 'pgcc'))
+        env.set('CXX', join_path(prefix.bin, 'pgc++'))
+        env.set('F77', join_path(prefix.bin, 'pgfortran'))
+        env.set('FC',  join_path(prefix.bin, 'pgfortran'))

--- a/packages/pgi/package.py
+++ b/packages/pgi/package.py
@@ -11,34 +11,7 @@ class Pgi(Package):
     """
     homepage = "http://www.pgroup.com/"
 
-    version('20.1', sha256='none')
-    version('19.9', sha256='none')
+    version('20.1', sha256='none', url='http://fake-link.tgz')
+    version('19.9', sha256='none', url='http://fake-link.tgz')
 
-    # Licensing
-    license_required = True
-    license_comment = '#'
-    license_files = ['license.dat']
-    license_vars = ['PGROUPD_LICENSE_FILE', 'LM_LICENSE_FILE']
-    license_url = 'http://www.pgroup.com/doc/pgiinstall.pdf'
-    
-    def url_for_version(self, version):
-        if int(str(version.up_to(1))) <= 17:
-            return "file://{0}/pgilinux-20{1}-{2}-x86_64.tar.gz".format(
-                os.getcwd(), version.up_to(1), version.joined)
-        else:
-            return "file://{0}/pgilinux-20{1}-{2}-x86-64.tar.gz".format(
-                os.getcwd(), version.up_to(1), version.joined)
 
-    def install(self, spec, prefix):
-        pass
-
-    def setup_run_environment(self, env):
-        prefix = Prefix(join_path(self.prefix, 'linux86-64', self.version))
-
-        env.prepend_path('PATH', prefix.bin)
-        env.prepend_path('MANPATH', prefix.man)
-        env.prepend_path('LD_LIBRARY_PATH', prefix.lib)
-        env.set('CC',  join_path(prefix.bin, 'pgcc'))
-        env.set('CXX', join_path(prefix.bin, 'pgc++'))
-        env.set('F77', join_path(prefix.bin, 'pgfortran'))
-        env.set('FC',  join_path(prefix.bin, 'pgfortran'))

--- a/sysconfigs/daint/compilers.yaml
+++ b/sysconfigs/daint/compilers.yaml
@@ -75,7 +75,7 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: pgi@20.1.0
+    spec: pgi@20.1
     paths:
       cc: cc
       cxx: CC
@@ -87,21 +87,6 @@ compilers:
     modules:
     - PrgEnv-pgi
     - pgi/20.1.0
-    environment: {}
-    extra_rpaths: []
-- compiler:
-    spec: pgi@20.1.1
-    paths:
-      cc: cc
-      cxx: CC
-      f77: ftn
-      fc: ftn
-    flags: {}
-    operating_system: cnl7
-    target: any
-    modules:
-    - PrgEnv-pgi
-    - pgi/20.1.1
     environment: {}
     extra_rpaths: []
 - compiler:
@@ -182,16 +167,4 @@ compilers:
     modules: []
     environment: {}
     extra_rpaths: []
-- compiler:
-    spec: pgi@20.1
-    paths:
-      cc: /opt/pgi/20.1.1/linux86-64/20.1/bin/pgcc
-      cxx: /opt/pgi/20.1.1/linux86-64/20.1/bin/pgc++
-      f77: /opt/pgi/20.1.1/linux86-64/20.1/bin/pgfortran
-      fc: /opt/pgi/20.1.1/linux86-64/20.1/bin/pgfortran
-    flags: {}
-    operating_system: sles15
-    target: x86_64
-    modules: []
-    environment: {}
-    extra_rpaths: []
+

--- a/sysconfigs/daint/compilers.yaml
+++ b/sysconfigs/daint/compilers.yaml
@@ -103,38 +103,12 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: gcc@8.1.0
-    paths:
-      cc: /opt/gcc/8.1.0/bin/gcc
-      cxx: /opt/gcc/8.1.0/bin/g++
-      f77: /opt/gcc/8.1.0/bin/gfortran
-      fc: /opt/gcc/8.1.0/bin/gfortran
-    flags: {}
-    operating_system: sles15
-    target: x86_64
-    modules: []
-    environment: {}
-    extra_rpaths: []
-- compiler:
     spec: gcc@8.3.0
     paths:
       cc: /opt/gcc/8.3.0/bin/gcc
       cxx: /opt/gcc/8.3.0/bin/g++
       f77: /opt/gcc/8.3.0/bin/gfortran
       fc: /opt/gcc/8.3.0/bin/gfortran
-    flags: {}
-    operating_system: sles15
-    target: x86_64
-    modules: []
-    environment: {}
-    extra_rpaths: []
-- compiler:
-    spec: gcc@9.3.0
-    paths:
-      cc: /opt/gcc/9.3.0/bin/gcc
-      cxx: /opt/gcc/9.3.0/bin/g++
-      f77: /opt/gcc/9.3.0/bin/gfortran
-      fc: /opt/gcc/9.3.0/bin/gfortran
     flags: {}
     operating_system: sles15
     target: x86_64

--- a/sysconfigs/daint/compilers.yaml
+++ b/sysconfigs/daint/compilers.yaml
@@ -86,7 +86,7 @@ compilers:
     target: any
     modules:
     - PrgEnv-pgi
-    - pgi/20.1.0
+    - pgi/20.1.1
     environment: {}
     extra_rpaths: []
 - compiler:

--- a/sysconfigs/daint/compilers.yaml
+++ b/sysconfigs/daint/compilers.yaml
@@ -15,87 +15,25 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: gcc@8.1.0
-    paths:
-      cc: cc
-      cxx: CC
-      f77: ftn
-      fc: ftn
-    flags: {}
-    operating_system: cnl7
-    target: any
-    modules:
-    - PrgEnv-gnu
-    - gcc/8.1.0
-    environment: {}
-    extra_rpaths: []
-- compiler:
-    spec: gcc@9.3.0
-    paths:
-      cc: cc
-      cxx: CC
-      f77: ftn
-      fc: ftn
-    flags: {}
-    operating_system: cnl7
-    target: any
-    modules:
-    - PrgEnv-gnu
-    - gcc/9.3.0
-    environment: {}
-    extra_rpaths: []
-- compiler:
-    spec: intel@19.0.1.144
-    paths:
-      cc: cc
-      cxx: CC
-      f77: ftn
-      fc: ftn
-    flags: {}
-    operating_system: cnl7
-    target: any
-    modules:
-    - PrgEnv-intel
-    - intel/19.0.1.144
-    environment: {}
-    extra_rpaths: []
-- compiler:
-    spec: intel@19.1.1.217
-    paths:
-      cc: cc
-      cxx: CC
-      f77: ftn
-      fc: ftn
-    flags: {}
-    operating_system: cnl7
-    target: any
-    modules:
-    - PrgEnv-intel
-    - intel/19.1.1.217
-    environment: {}
-    extra_rpaths: []
-- compiler:
-    spec: pgi@20.1
-    paths:
-      cc: cc
-      cxx: CC
-      f77: ftn
-      fc: ftn
-    flags: {}
-    operating_system: cnl7
-    target: any
-    modules:
-    - PrgEnv-pgi
-    - pgi/20.1.1
-    environment: {}
-    extra_rpaths: []
-- compiler:
     spec: gcc@7.5.0
     paths:
-      cc: /usr/bin/gcc
-      cxx: /usr/bin/g++
-      f77: /usr/bin/gfortran
-      fc: /usr/bin/gfortran
+      cc: /usr/bin/gcc-7
+      cxx: /usr/bin/g++-7
+      f77: /usr/bin/gfortran-7
+      fc: /usr/bin/gfortran-7
+    flags: {}
+    operating_system: sles15
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: gcc@8.1.0
+    paths:
+      cc: /opt/gcc/8.1.0/bin/gcc
+      cxx: /opt/gcc/8.1.0/bin/g++
+      f77: /opt/gcc/8.1.0/bin/gfortran
+      fc: /opt/gcc/8.1.0/bin/gfortran
     flags: {}
     operating_system: sles15
     target: x86_64
@@ -109,6 +47,19 @@ compilers:
       cxx: /opt/gcc/8.3.0/bin/g++
       f77: /opt/gcc/8.3.0/bin/gfortran
       fc: /opt/gcc/8.3.0/bin/gfortran
+    flags: {}
+    operating_system: sles15
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: gcc@9.3.0
+    paths:
+      cc: /opt/gcc/9.3.0/bin/gcc
+      cxx: /opt/gcc/9.3.0/bin/g++
+      f77: /opt/gcc/9.3.0/bin/gfortran
+      fc: /opt/gcc/9.3.0/bin/gfortran
     flags: {}
     operating_system: sles15
     target: x86_64
@@ -141,4 +92,18 @@ compilers:
     modules: []
     environment: {}
     extra_rpaths: []
+- compiler:
+    spec: pgi@20.1
+    paths:
+      cc: /opt/pgi/20.1.1/linux86-64/20.1/bin/pgcc
+      cxx: /opt/pgi/20.1.1/linux86-64/20.1/bin/pgc++
+      f77: /opt/pgi/20.1.1/linux86-64/20.1/bin/pgfortran
+      fc: /opt/pgi/20.1.1/linux86-64/20.1/bin/pgfortran
+    flags: {}
+    operating_system: cnl7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+
 

--- a/sysconfigs/daint/packages.yaml
+++ b/sysconfigs/daint/packages.yaml
@@ -31,11 +31,8 @@ packages:
              bzip2@1.0.6: /usr
     cce:
         buildable: false
-        externals:
-        - spec: cce@10.0.2
-          modules:
-          - PrgEnv-cray
-          - cce/10.0.2
+        modules:
+          cce@10.0.2: PrgEnv-cray cce/10.0.2
     cosmo:
       variants: cuda_arch=60 cosmo_target=gpu slave=daint
       version: [master]
@@ -96,15 +93,9 @@ packages:
 
     gcc:
         buildable: false
-        externals:
-        - spec: gcc@8.1.0
-          modules:
-          - PrgEnv-gnu
-          - gcc/8.1.0
-        - spec: gcc@9.3.0
-          modules:
-          - PrgEnv-gnu
-          - gcc/9.3.0
+        modules:
+          gcc@8.1.0: PrgEnv-gnu gcc/8.1.0
+          gcc@9.3.0: PrgEnv-gnu gcc/9.3.0
     gettext:
         paths:
              gettext@0.19.8.1: /usr
@@ -133,15 +124,9 @@ packages:
         variants: +cuda
     intel:
         buildable: false
-        externals:
-        - spec: intel@19.0.1.144
-          modules:
-          - PrgEnv-intel
-          - intel/19.0.1.144
-        - spec: intel@19.1.1.217
-          modules:
-          - PrgEnv-intel
-          - intel/19.1.1.217
+        modules:
+          intel@19.0.1.144: PrgEnv-intel intel/19.0.1.144
+          intel@19.1.1.217: PrgEnv-intel intel/19.1.1.217
     intel-mkl:
         buildable: false
         paths:
@@ -249,10 +234,8 @@ packages:
 
     pgi:
         buildable: false
-        externals:
-        - spec: pgi@20.1
-          prefix: /opt/pgi/20.1.0
-
+        modules:
+          pgi@20.1: PrgEnv-pgi pgi/20.1.1
     quantum-espresso:
         variants: ~elpa +mpi +openmp
     readline:

--- a/sysconfigs/daint/packages.yaml
+++ b/sysconfigs/daint/packages.yaml
@@ -29,6 +29,13 @@ packages:
     bzip2:
         paths:
              bzip2@1.0.6: /usr
+    cce:
+        buildable: false
+        externals:
+        - spec: cce@10.0.2
+          modules:
+          - PrgEnv-cray
+          - cce/10.0.2
     cosmo:
       variants: cuda_arch=60 cosmo_target=gpu slave=daint
       version: [master]
@@ -86,6 +93,18 @@ packages:
     gawk:
         paths:
              gawk@4.2.1: /usr
+
+    gcc:
+        buildable: false
+        externals:
+        - spec: gcc@8.1.0
+          modules:
+          - PrgEnv-gnu
+          - gcc/8.1.0
+        - spec: gcc@9.3.0
+          modules:
+          - PrgEnv-gnu
+          - gcc/9.3.0
     gettext:
         paths:
              gettext@0.19.8.1: /usr

--- a/sysconfigs/daint/packages.yaml
+++ b/sysconfigs/daint/packages.yaml
@@ -219,9 +219,9 @@ packages:
 
     pgi:
         buildable: false
-        modules:
-            pgi@20.1.0:   pgi/20.1.0
-            pgi@20.1.1:   pgi/20.1.1
+        externals:
+        - spec: pgi@20.1
+          prefix: /opt/pgi/20.1.0
 
     quantum-espresso:
         variants: ~elpa +mpi +openmp

--- a/sysconfigs/daint/packages.yaml
+++ b/sysconfigs/daint/packages.yaml
@@ -216,6 +216,13 @@ packages:
             petsc@3.13.3.0%intel+complex+int64:  cray-petsc-complex-64/3.13.3.0
             petsc@3.13.3.0%cce+complex+int64:    cray-petsc-complex-64/3.13.3.0
             petsc@3.13.3.0%pgi+complex+int64:    cray-petsc-complex-64/3.13.3.0
+
+    pgi:
+        buildable: false
+        modules:
+            pgi@20.1.0:   pgi/20.1.0
+            pgi@20.1.1:   pgi/20.1.1
+
     quantum-espresso:
         variants: ~elpa +mpi +openmp
     readline:

--- a/sysconfigs/daint/packages.yaml
+++ b/sysconfigs/daint/packages.yaml
@@ -4,7 +4,7 @@ packages:
     all:
         # default compilers defined by the system
         # these reflect the current installed PE
-        compiler: [pgi@20.1.1, pgi@20.1.0, gcc@9.3.0, gcc@8.1.0, cce@10.0.2, intel@19.1.1.217, intel@19.0.1.144]
+        compiler: [pgi@20.1, gcc@9.3.0, gcc@8.1.0, cce@10.0.2, intel@19.1.1.217, intel@19.0.1.144]
         providers:
             mpi: [mpich]
             # if the mpich package support +cuda in the future it needs to be put there
@@ -112,6 +112,17 @@ packages:
             hdf5@1.12.0.0%pgi+mpi+hl+fortran:   cray-hdf5-parallel/1.12.0.0
     hwloc:
         variants: +cuda
+    intel:
+        buildable: false
+        externals:
+        - spec: intel@19.0.1.144
+          modules:
+          - PrgEnv-intel
+          - intel/19.0.1.144
+        - spec: intel@19.1.1.217
+          modules:
+          - PrgEnv-intel
+          - intel/19.1.1.217
     intel-mkl:
         buildable: false
         paths:

--- a/sysconfigs/tsa/compilers.yaml
+++ b/sysconfigs/tsa/compilers.yaml
@@ -1,29 +1,27 @@
 compilers::
 - compiler:
-    environment: {}
-    extra_rpaths: []
-    flags: {}
-    modules: 
-    - /apps/arolla/UES/jenkins/RH7.7/pgi/19.9/easybuild/modules/all/pgi/19.9-gcc-8.3.0
-    operating_system: rhel7
-    paths:
-      cc: pgcc
-      cxx: pgc++
-      f77: pgfortran
-      fc: pgfortran
     spec: pgi@19.9
+    paths:
+      cc: /apps/arolla/UES/jenkins/RH7.7/MCH-PE20.06/pgi/19.9/easybuild/software/PGI/19.9-GCC-8.3.0/linux86-64/19.9/bin/pgcc
+      cxx: /apps/arolla/UES/jenkins/RH7.7/MCH-PE20.06/pgi/19.9/easybuild/software/PGI/19.9-GCC-8.3.0/linux86-64/19.9/bin/pgc++
+      f77: /apps/arolla/UES/jenkins/RH7.7/MCH-PE20.06/pgi/19.9/easybuild/software/PGI/19.9-GCC-8.3.0/linux86-64/19.9/bin/pgfortran
+      fc: /apps/arolla/UES/jenkins/RH7.7/MCH-PE20.06/pgi/19.9/easybuild/software/PGI/19.9-GCC-8.3.0/linux86-64/19.9/bin/pgfortran
+    operating_system: rhel7
     target: any
-- compiler:
+    modules: []
     environment: {}
     extra_rpaths: []
     flags: {}
-    modules: 
-    - gcc/8.3.0
-    operating_system: rhel7
+- compiler:
+    spec: gcc@8.3.0
     paths:
       cc: /apps/arolla/UES/jenkins/RH7.7/generic/easybuild/software/GCCcore/8.3.0/bin/gcc
       cxx: /apps/arolla/UES/jenkins/RH7.7/generic/easybuild/software/GCCcore/8.3.0/bin/g++
       f77: /apps/arolla/UES/jenkins/RH7.7/generic/easybuild/software/GCCcore/8.3.0/bin/gfortran
       fc: /apps/arolla/UES/jenkins/RH7.7/generic/easybuild/software/GCCcore/8.3.0/bin/gfortran
-    spec: gcc@8.3.0
+    operating_system: rhel7
     target: any
+    modules: []
+    environment: {}
+    extra_rpaths: []
+    flags: {}

--- a/sysconfigs/tsa/packages.yaml
+++ b/sysconfigs/tsa/packages.yaml
@@ -4,6 +4,8 @@ packages:
     providers:
       mpicuda: [openmpi+cuda, mpich]
       mpi: [openmpi~cuda]
+  cce:
+      buildable: false
   cmake:
     modules:
       cmake@3.14.5%gcc: cmake/3.14.5
@@ -21,6 +23,14 @@ packages:
     version: []
     target: []
     providers: {}
+  gcc:
+    buildable: false
+    externals:
+    - spec: gcc@8.3.0
+      modules:
+      - gcc/8.3.0
+  intel:
+    buildable: false
   openmpi:
     modules:
       openmpi@4.0.2%pgi +cuda: /apps/arolla/UES/jenkins/RH7.7/MCH-PE20.06/pgi/19.9/easybuild/modules/all/openmpi/4.0.2-pgi-19.9-gcc-8.3.0-cuda-10.1-rh7.7
@@ -42,6 +52,11 @@ packages:
   perl:
     paths: 
       perl@5.16.3: /usr
+  pgi:
+        buildable: false
+        externals:
+        - spec: pgi@19.9
+          prefix: PrgEnv-pgi/19.9
   m4:
     paths: 
       m4@1.4.16%gcc: /usr
@@ -95,10 +110,4 @@ packages:
     variants: cuda_arch=70 cosmo_target=gpu slave=tsa
     version: [master]
     compiler: [pgi@19.9, gcc@8.3.0]
-
-    pgi:
-        buildable: false
-        externals:
-        - spec: pgi@19.9
-          prefix: /apps/arolla/UES/jenkins/RH7.7/MCH-PE20.06/pgi/19.9/easybuild/software/PGI/19.9-GCC-8.3.0
 

--- a/sysconfigs/tsa/packages.yaml
+++ b/sysconfigs/tsa/packages.yaml
@@ -96,3 +96,9 @@ packages:
     version: [master]
     compiler: [pgi@19.9, gcc@8.3.0]
 
+    pgi:
+        buildable: false
+        externals:
+        - spec: pgi@19.9
+          prefix: /apps/arolla/UES/jenkins/RH7.7/MCH-PE20.06/pgi/19.9/easybuild/software/PGI/19.9-GCC-8.3.0
+

--- a/sysconfigs/tsa/packages.yaml
+++ b/sysconfigs/tsa/packages.yaml
@@ -25,10 +25,8 @@ packages:
     providers: {}
   gcc:
     buildable: false
-    externals:
-    - spec: gcc@8.3.0
-      modules:
-      - gcc/8.3.0
+    modules:
+      gcc@8.3.0: gcc/8.3.0
   intel:
     buildable: false
   openmpi:
@@ -53,10 +51,9 @@ packages:
     paths: 
       perl@5.16.3: /usr
   pgi:
-        buildable: false
-        externals:
-        - spec: pgi@19.9
-          prefix: PrgEnv-pgi/19.9
+    buildable: false
+    modules:
+      pgi@19.9: PrgEnv-pgi/19.9
   m4:
     paths: 
       m4@1.4.16%gcc: /usr


### PR DESCRIPTION
Adds external packages for compilers used on daint & tsa
Patches CLAW to use direct path to Fortran compiler instead of spack wrapper