### PR TITLE
Fix CLAW runtime Fortran compiler

### DIFF
--- a/packages/claw/package.py
+++ b/packages/claw/package.py
@@ -4,6 +4,26 @@
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 from spack import *
+from spack.spec import Spec
+from spack.version import Version, VersionRange
+
+
+def _fc_variant_name(cp):
+    return str(cp.spec).replace('@', '')
+
+
+def _fc_variant_get_compiler(fc_variant_name):
+    for cp in spack.compilers.all_compilers():
+        if _fc_variant_name(cp) == fc_variant_name:
+            return cp
+    return None
+
+
+def _add_claw_fc_variant():
+    cp_spec_by_val = {_fc_variant_name(cp): str(cp.spec) for cp in spack.compilers.all_compilers()}
+    cp_vals = tuple(['build-fc'] + [cp_name for cp_name in cp_spec_by_val])
+    variant('fc', description='Fortran compiler, used by CLAW at runtime. "build-fc" means that CLAW should use ' +
+                              'build-time compiler', default='build-fc', values=cp_vals, multi=False)
 
 
 class Claw(CMakePackage):
@@ -12,19 +32,21 @@ class Claw(CMakePackage):
        generates architecture specific code decorated with OpenMP or OpenACC"""
 
     homepage = 'https://claw-project.github.io/'
-    git      = 'https://github.com/claw-project/claw-compiler.git'
+    git = 'https://github.com/claw-project/claw-compiler.git'
     maintainers = ['clementval']
 
     version('master', branch='master', submodules=True)
     version('2.0.2', commit='8c012d58484d8caf79a4fe45597dc74b4367421c', submodules=True)
     version('2.0.1', commit='f5acc929df74ce66a328aa4eda9cc9664f699b91', submodules=True)
-    version('2.0',   commit='53e705b8bfce40a5c5636e8194a7622e337cf4f5', submodules=True)
+    version('2.0', commit='53e705b8bfce40a5c5636e8194a7622e337cf4f5', submodules=True)
     version('1.2.3', commit='eaf5e5fb39150090e51bec1763170ce5c5355198', submodules=True)
     version('1.2.2', commit='fc27a267eef9f412dd6353dc0b358a05b3fb3e16', submodules=True)
     version('1.2.1', commit='939989ab52edb5c292476e729608725654d0a59a', submodules=True)
     version('1.2.0', commit='fc9c50fe02be97b910ff9c7015064f89be88a3a2', submodules=True)
     version('1.1.0', commit='16b165a443b11b025a77cad830b1280b8c9bcf01', submodules=True)
-    
+
+    _add_claw_fc_variant()
+
     variant('omni-master', default=False, description='Build with the master version of the omni-compiler')
 
     depends_on('cmake@3.0:%gcc', type='build')
@@ -34,20 +56,32 @@ class Claw(CMakePackage):
     depends_on('libxml2%gcc')
     depends_on('bison%gcc')
     depends_on('flex%gcc')
-    
+
     def setup_environment(self, spack_env, run_env):
         spack_env.set('YACC', 'bison -y')
+
+    def _get_fc_runtime_path(self):
+        fc_variant_val = self.spec.variants['fc'].value
+        if fc_variant_val == 'build-fc':
+            fc_variant_val = _fc_variant_name(self.compiler)
+
+        compiler = _fc_variant_get_compiler(fc_variant_val)
+        assert compiler is not None, "Compiler %s not found" % fc_variant_val
+        return compiler.fc
+
+    def patch(self):
+        if self.version in VersionRange(Version('2.0'), Version('2.0.2')):
+            filter_file('${CMAKE_Fortran_COMPILER}', '${CLAW_Fortran_COMPILER}',
+                        'CMakeLists.txt', 'properties.cmake', 'cmake/omni_compiler.cmake', string=True)
+
     def cmake_args(self):
         args = []
         spec = self.spec
-        
+
         if spec.variants['omni-master'].value:
             args.append('-DOMNI_GIT_HASH=master')
 
-        args.append('-DOMNI_CONF_OPTION=--with-libxml2={0}'.
-                    format(spec['libxml2'].prefix))
+        args.append('-DOMNI_CONF_OPTION=--with-libxml2=%s' % spec['libxml2'].prefix)
 
-        args.append('-DCMAKE_Fortran_COMPILER={0}'.
-                    format(self.compiler.fc))
-
+        args.append('-DCLAW_Fortran_COMPILER=%s' % self._get_fc_runtime_path())
         return args

--- a/sysconfigs/daint/compilers.yaml
+++ b/sysconfigs/daint/compilers.yaml
@@ -188,21 +188,6 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: pgi@20.1.0
-    paths:
-      cc: cc
-      cxx: CC
-      f77: ftn
-      fc: ftn
-    flags: {}
-    operating_system: cnl7
-    target: any
-    modules:
-    - PrgEnv-pgi
-    - pgi/20.1.0
-    environment: {}
-    extra_rpaths: []
-- compiler:
     spec: pgi@20.1
     paths:
       cc: /opt/pgi/20.1.1/linux86-64/20.1/bin/pgcc

--- a/sysconfigs/daint/compilers.yaml
+++ b/sysconfigs/daint/compilers.yaml
@@ -15,33 +15,146 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: gcc@8.1.0
+    spec: intel@19.0.1.144
     paths:
-      cc: cc
-      cxx: CC
-      f77: ftn
-      fc: ftn
+      cc: /opt/intel/compilers_and_libraries_2019.1.144/linux/bin/intel64/icc
+      cxx: /opt/intel/compilers_and_libraries_2019.1.144/linux/bin/intel64/icpc
+      f77: /opt/intel/compilers_and_libraries_2019.1.144/linux/bin/intel64/ifort
+      fc: /opt/intel/compilers_and_libraries_2019.1.144/linux/bin/intel64/ifort
     flags: {}
     operating_system: cnl7
-    target: any
-    modules:
-    - PrgEnv-gnu
-    - gcc/8.1.0
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: intel@19.0.1.144
+    paths:
+      cc: /opt/intel/compilers_and_libraries_2019.1.144/linux/bin/intel64/icc
+      cxx: /opt/intel/compilers_and_libraries_2019.1.144/linux/bin/intel64/icpc
+      f77: /opt/intel/compilers_and_libraries_2019.1.144/linux/bin/intel64/ifort
+      fc: /opt/intel/compilers_and_libraries_2019.1.144/linux/bin/intel64/ifort
+    flags: {}
+    operating_system: sles15
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: intel@19.1.1.217
+    paths:
+      cc: /opt/intel/compilers_and_libraries_2020.1.217/linux/bin/intel64/icc
+      cxx: /opt/intel/compilers_and_libraries_2020.1.217/linux/bin/intel64/icpc
+      f77: /opt/intel/compilers_and_libraries_2020.1.217/linux/bin/intel64/ifort
+      fc: /opt/intel/compilers_and_libraries_2020.1.217/linux/bin/intel64/ifort
+    flags: {}
+    operating_system: cnl7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: intel@19.1.1.217
+    paths:
+      cc: /opt/intel/compilers_and_libraries_2020.1.217/linux/bin/intel64/icc
+      cxx: /opt/intel/compilers_and_libraries_2020.1.217/linux/bin/intel64/icpc
+      f77: /opt/intel/compilers_and_libraries_2020.1.217/linux/bin/intel64/ifort
+      fc: /opt/intel/compilers_and_libraries_2020.1.217/linux/bin/intel64/ifort
+    flags: {}
+    operating_system: sles15
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: gcc@7.5.0
+    paths:
+      cc: /usr/bin/gcc-7
+      cxx: /usr/bin/g++-7
+      f77: /usr/bin/gfortran-7
+      fc: /usr/bin/gfortran-7
+    flags: {}
+    operating_system: sles15
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: gcc@8.1.0
+    paths:
+      cc: /opt/gcc/8.1.0/bin/gcc
+      cxx: /opt/gcc/8.1.0/bin/g++
+      f77: /opt/gcc/8.1.0/bin/gfortran
+      fc: /opt/gcc/8.1.0/bin/gfortran
+    flags: {}
+    operating_system: cnl7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: gcc@8.1.0
+    paths:
+      cc: /opt/gcc/8.1.0/bin/gcc
+      cxx: /opt/gcc/8.1.0/bin/g++
+      f77: /opt/gcc/8.1.0/bin/gfortran
+      fc: /opt/gcc/8.1.0/bin/gfortran
+    flags: {}
+    operating_system: sles15
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: gcc@8.3.0
+    paths:
+      cc: /opt/gcc/8.3.0/bin/gcc
+      cxx: /opt/gcc/8.3.0/bin/g++
+      f77: /opt/gcc/8.3.0/bin/gfortran
+      fc: /opt/gcc/8.3.0/bin/gfortran
+    flags: {}
+    operating_system: cnl7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: gcc@8.3.0
+    paths:
+      cc: /opt/gcc/8.3.0/bin/gcc
+      cxx: /opt/gcc/8.3.0/bin/g++
+      f77: /opt/gcc/8.3.0/bin/gfortran
+      fc: /opt/gcc/8.3.0/bin/gfortran
+    flags: {}
+    operating_system: sles15
+    target: x86_64
+    modules: []
     environment: {}
     extra_rpaths: []
 - compiler:
     spec: gcc@9.3.0
     paths:
-      cc: cc
-      cxx: CC
-      f77: ftn
-      fc: ftn
+      cc: /opt/gcc/9.3.0/bin/gcc
+      cxx: /opt/gcc/9.3.0/bin/g++
+      f77: /opt/gcc/9.3.0/bin/gfortran
+      fc: /opt/gcc/9.3.0/bin/gfortran
     flags: {}
     operating_system: cnl7
-    target: any
-    modules:
-    - PrgEnv-gnu
-    - gcc/9.3.0
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: gcc@9.3.0
+    paths:
+      cc: /opt/gcc/9.3.0/bin/gcc
+      cxx: /opt/gcc/9.3.0/bin/g++
+      f77: /opt/gcc/9.3.0/bin/gfortran
+      fc: /opt/gcc/9.3.0/bin/gfortran
+    flags: {}
+    operating_system: sles15
+    target: x86_64
+    modules: []
     environment: {}
     extra_rpaths: []
 - compiler:
@@ -90,94 +203,14 @@ compilers:
     environment: {}
     extra_rpaths: []
 - compiler:
-    spec: pgi@20.1.1
+    spec: pgi@20.1
     paths:
-      cc: cc
-      cxx: CC
-      f77: ftn
-      fc: ftn
+      cc: /opt/pgi/20.1.1/linux86-64/20.1/bin/pgcc
+      cxx: /opt/pgi/20.1.1/linux86-64/20.1/bin/pgc++
+      f77: /opt/pgi/20.1.1/linux86-64/20.1/bin/pgfortran
+      fc: /opt/pgi/20.1.1/linux86-64/20.1/bin/pgfortran
     flags: {}
     operating_system: cnl7
-    target: any
-    modules:
-    - PrgEnv-pgi
-    - pgi/20.1.1
-    environment: {}
-    extra_rpaths: []
-- compiler:
-    spec: gcc@7.5.0
-    paths:
-      cc: /usr/bin/gcc
-      cxx: /usr/bin/g++
-      f77: /usr/bin/gfortran
-      fc: /usr/bin/gfortran
-    flags: {}
-    operating_system: sles15
-    target: x86_64
-    modules: []
-    environment: {}
-    extra_rpaths: []
-- compiler:
-    spec: gcc@8.1.0
-    paths:
-      cc: /opt/gcc/8.1.0/bin/gcc
-      cxx: /opt/gcc/8.1.0/bin/g++
-      f77: /opt/gcc/8.1.0/bin/gfortran
-      fc: /opt/gcc/8.1.0/bin/gfortran
-    flags: {}
-    operating_system: sles15
-    target: x86_64
-    modules: []
-    environment: {}
-    extra_rpaths: []
-- compiler:
-    spec: gcc@8.3.0
-    paths:
-      cc: /opt/gcc/8.3.0/bin/gcc
-      cxx: /opt/gcc/8.3.0/bin/g++
-      f77: /opt/gcc/8.3.0/bin/gfortran
-      fc: /opt/gcc/8.3.0/bin/gfortran
-    flags: {}
-    operating_system: sles15
-    target: x86_64
-    modules: []
-    environment: {}
-    extra_rpaths: []
-- compiler:
-    spec: gcc@9.3.0
-    paths:
-      cc: /opt/gcc/9.3.0/bin/gcc
-      cxx: /opt/gcc/9.3.0/bin/g++
-      f77: /opt/gcc/9.3.0/bin/gfortran
-      fc: /opt/gcc/9.3.0/bin/gfortran
-    flags: {}
-    operating_system: sles15
-    target: x86_64
-    modules: []
-    environment: {}
-    extra_rpaths: []
-- compiler:
-    spec: intel@19.0.1.144
-    paths:
-      cc: /opt/intel/compilers_and_libraries_2019.1.144/linux/bin/intel64/icc
-      cxx: /opt/intel/compilers_and_libraries_2019.1.144/linux/bin/intel64/icpc
-      f77: /opt/intel/compilers_and_libraries_2019.1.144/linux/bin/intel64/ifort
-      fc: /opt/intel/compilers_and_libraries_2019.1.144/linux/bin/intel64/ifort
-    flags: {}
-    operating_system: sles15
-    target: x86_64
-    modules: []
-    environment: {}
-    extra_rpaths: []
-- compiler:
-    spec: intel@19.1.1.217
-    paths:
-      cc: /opt/intel/compilers_and_libraries_2020.1.217/linux/bin/intel64/icc
-      cxx: /opt/intel/compilers_and_libraries_2020.1.217/linux/bin/intel64/icpc
-      f77: /opt/intel/compilers_and_libraries_2020.1.217/linux/bin/intel64/ifort
-      fc: /opt/intel/compilers_and_libraries_2020.1.217/linux/bin/intel64/ifort
-    flags: {}
-    operating_system: sles15
     target: x86_64
     modules: []
     environment: {}

--- a/sysconfigs/daint/packages.yaml
+++ b/sysconfigs/daint/packages.yaml
@@ -4,7 +4,7 @@ packages:
     all:
         # default compilers defined by the system
         # these reflect the current installed PE
-        compiler: [pgi@20.1.1, pgi@20.1.0, gcc@9.3.0, gcc@8.1.0, cce@10.0.2, intel@19.1.1.217, intel@19.0.1.144]
+        compiler: [pgi@20.1, gcc@9.3.0, gcc@8.1.0, cce@10.0.2, intel@19.1.1.217, intel@19.0.1.144]
         providers:
             mpi: [mpich]
             # if the mpich package support +cuda in the future it needs to be put there

--- a/sysconfigs/tsa/compilers.yaml
+++ b/sysconfigs/tsa/compilers.yaml
@@ -1,29 +1,27 @@
 compilers::
 - compiler:
-    environment: {}
-    extra_rpaths: []
-    flags: {}
-    modules: 
-    - /apps/arolla/UES/jenkins/RH7.7/pgi/19.9/easybuild/modules/all/pgi/19.9-gcc-8.3.0
-    operating_system: rhel7
-    paths:
-      cc: pgcc
-      cxx: pgc++
-      f77: pgfortran
-      fc: pgfortran
     spec: pgi@19.9
+    paths:
+      cc: /apps/arolla/UES/jenkins/RH7.7/MCH-PE20.06/pgi/19.9/easybuild/software/PGI/19.9-GCC-8.3.0/linux86-64/19.9/bin/pgcc
+      cxx: /apps/arolla/UES/jenkins/RH7.7/MCH-PE20.06/pgi/19.9/easybuild/software/PGI/19.9-GCC-8.3.0/linux86-64/19.9/bin/pgc++
+      f77: /apps/arolla/UES/jenkins/RH7.7/MCH-PE20.06/pgi/19.9/easybuild/software/PGI/19.9-GCC-8.3.0/linux86-64/19.9/bin/pgfortran
+      fc: /apps/arolla/UES/jenkins/RH7.7/MCH-PE20.06/pgi/19.9/easybuild/software/PGI/19.9-GCC-8.3.0/linux86-64/19.9/bin/pgfortran
+    operating_system: rhel7
     target: any
-- compiler:
+    modules: []
     environment: {}
     extra_rpaths: []
     flags: {}
-    modules: 
-    - gcc/8.3.0
-    operating_system: rhel7
+- compiler:
+    spec: gcc@8.3.0
     paths:
       cc: /apps/arolla/UES/jenkins/RH7.7/generic/easybuild/software/GCCcore/8.3.0/bin/gcc
       cxx: /apps/arolla/UES/jenkins/RH7.7/generic/easybuild/software/GCCcore/8.3.0/bin/g++
       f77: /apps/arolla/UES/jenkins/RH7.7/generic/easybuild/software/GCCcore/8.3.0/bin/gfortran
       fc: /apps/arolla/UES/jenkins/RH7.7/generic/easybuild/software/GCCcore/8.3.0/bin/gfortran
-    spec: gcc@8.3.0
+    operating_system: rhel7
     target: any
+    modules: []
+    environment: {}
+    extra_rpaths: []
+    flags: {}


### PR DESCRIPTION
Makes spack compilers use paths instead of modules on Daint and Tsa.
Patches CLAW to use direct path to Fortran compiler instead of spack wrapper.