### PR TITLE
Fix dawn package.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ sysconfigs/upstreams.yaml
 **.swn
 **.swp
 **.swo
+/spack

--- a/packages/dawn/package.py
+++ b/packages/dawn/package.py
@@ -19,7 +19,9 @@ class Dawn(CMakePackage):
 
     depends_on('cmake')
     depends_on('python@3.8.0')
-
+    depends_on('py-setuptools', type='build')
+    depends_on('py-protobuf', type=('build','run'))
+    
     variant('build_type', default='Release', description='Build type', values=('Debug', 'Release', 'DebugRelease'))
     root_cmakelists_dir='dawn'
 


### PR DESCRIPTION
To install python stuff need to depend on `py-setuptools` and `py-protobuf`.
Also sneaked in: git ignore of spack installation in folder `spack` under root (annoying when preparing commits).