### PR TITLE
Removed buggy & optional datapath

### DIFF
--- a/packages/cosmo-dycore/package.py
+++ b/packages/cosmo-dycore/package.py
@@ -139,6 +139,6 @@ class CosmoDycore(CMakePackage):
     def test(self):
       if '+build_tests' in self.spec:
           try:
-              subprocess.run(['./test_dycore.py', '-s', str(self.spec), '-b', str(self.build_directory), '-d', self.spec.variants['data_path'].value], cwd = self.root_cmakelists_dir + '/test/tools', check=True, stderr=subprocess.STDOUT)
+              subprocess.run(['./test_dycore.py', '-s', str(self.spec), '-b', str(self.build_directory)], cwd = self.root_cmakelists_dir + '/test/tools', check=True, stderr=subprocess.STDOUT)
           except:
               raise InstallError('Dycore tests failed')


### PR DESCRIPTION
I actually broke this myself. In https://github.com/COSMO-ORG/cosmo/pull/319 I changed the _interface_ of the testtool. This updates the `cosmo-dycore` package so it works with the changes.