### PR TITLE
Added dusk version with fixed commit for icondusk

### DIFF
--- a/packages/dusk/package.py
+++ b/packages/dusk/package.py
@@ -15,7 +15,7 @@ class Dusk(PythonPackage):
     maintainers = ['BenWeber42']
 
     version('master', branch='master')
-    version('0.4-dev_icondusk-e2e', commit='1b9793ce3e550c8561483f668893b16177ca503b')
+    version('icondusk-e2e', tag='icondusk-e2e')
 
     extends('python@3.8.0:3.8.999')
 

--- a/packages/dusk/package.py
+++ b/packages/dusk/package.py
@@ -15,6 +15,7 @@ class Dusk(PythonPackage):
     maintainers = ['BenWeber42']
 
     version('master', branch='master')
+    version('0.4-dev_icondusk-e2e', commit='1b9793ce3e550c8561483f668893b16177ca503b')
 
     extends('python@3.8.0:3.8.999')
 

--- a/packages/icondusk-e2e/package.py
+++ b/packages/icondusk-e2e/package.py
@@ -18,7 +18,7 @@ class IconduskE2e(CMakePackage):
     maintainers = ['cosunae']
 
     version('master', branch='master')
-    version('0.1-dev', branch='master')
+    version('0.1-dev', tag='0.1-dev')
 
     depends_on('cmake@3.17.0:')
     depends_on('boost@1.73.0%gcc')

--- a/packages/icondusk-e2e/package.py
+++ b/packages/icondusk-e2e/package.py
@@ -18,6 +18,7 @@ class IconduskE2e(CMakePackage):
     maintainers = ['cosunae']
 
     version('master', branch='master')
+    version('0.1-dev', branch='master')
 
     depends_on('cmake@3.17.0:')
     depends_on('boost@1.73.0%gcc')
@@ -25,7 +26,8 @@ class IconduskE2e(CMakePackage):
     depends_on('netcdf-c')
     depends_on('atlas_utilities', type=('build', 'run'))
     depends_on('dawn4py',  type=('build'))
-    depends_on('dusk@0.4-dev_icondusk-e2e',  type=('build'))
+    depends_on('dusk',  type=('build'))
+    depends_on('dusk@icondusk-e2e',  type=('build'), when='@0.1-dev')
     depends_on('python@3.8.0')
     depends_on('atlas@0.22.0')
     depends_on('cuda', type=('build', 'run'))

--- a/packages/icondusk-e2e/package.py
+++ b/packages/icondusk-e2e/package.py
@@ -25,7 +25,7 @@ class IconduskE2e(CMakePackage):
     depends_on('netcdf-c')
     depends_on('atlas_utilities', type=('build', 'run'))
     depends_on('dawn4py',  type=('build'))
-    depends_on('dusk',  type=('build'))
+    depends_on('dusk@0.4-dev_icondusk-e2e',  type=('build'))
     depends_on('python@3.8.0')
     depends_on('atlas@0.22.0')
     depends_on('cuda', type=('build', 'run'))


### PR DESCRIPTION
I think it's better if `icondusk-e2e` uses a fixed commit from `dusk`. However, I think it'll break the `icondusk-e2e_PR` jenkins plan, since that plan works only if `icondusk-e2e` can use _any_ version of `dusk`.