### PR TITLE
FIX: v0.16.0

### DIFF
--- a/config.py
+++ b/config.py
@@ -63,7 +63,7 @@ def main():
     if not args.stgidir:
         args.stgidir = '$SCRATCH'
 
-    config_data['config']['install_tree'] = args.pckgidir + '/spack-install/' + args.machine.replace('admin-', '')
+    config_data['config']['install_tree']['root'] = args.pckgidir + '/spack-install/' + args.machine.replace('admin-', '')
     config_data['config']['build_stage'] = [args.stgidir + '/spack-stages/' + args.machine]
     config_data['config']['module_roots']['tcl'] = args.pckgidir + '/modules/' + args.machine
     config_data['config']['extensions'] = [dir_path + '/tools/spack-scripting']

--- a/config.py
+++ b/config.py
@@ -8,7 +8,7 @@ import subprocess
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 
-spack_version='v0.15.4'
+spack_version='v0.16.0'
 spack_repo='git@github.com:spack/spack.git'
 
 def main():

--- a/packages/cosmo/package.py
+++ b/packages/cosmo/package.py
@@ -57,7 +57,7 @@ class Cosmo(MakefilePackage):
 
     dycore_deps(apngit)
 
-    depends_on('netcdf-fortran +mpi', type=('build', 'link'))
+    depends_on('netcdf-fortran', type=('build', 'link'))
     depends_on('netcdf-c +mpi', type=('build', 'link'))
     depends_on('slurm%gcc', type='run')
     depends_on('cuda%gcc', when='cosmo_target=gpu', type=('build', 'link', 'run'))

--- a/packages/int2lm/package.py
+++ b/packages/int2lm/package.py
@@ -48,7 +48,7 @@ class Int2lm(MakefilePackage):
     depends_on('libgrib1@master')
     depends_on('mpi', type=('build', 'link', 'run'), when='+parallel')
     depends_on('netcdf-c')
-    depends_on('netcdf-fortran +mpi')
+    depends_on('netcdf-fortran')
 
     variant('debug', default=False, description='Build debug INT2LM')
     variant('eccodes', default=True, description='Build with eccodes instead of grib-api')

--- a/sysconfigs/daint/config.yaml
+++ b/sysconfigs/daint/config.yaml
@@ -1,12 +1,14 @@
 config:
-  install_tree:
-  template_dirs:
-    - $spack/templates
-  module_roots:
-    tcl:
-  build_stage:
-  extensions:
-  install_path_scheme: '{name}/{version}/{compiler.name}/{hash}'
-  source_cache: ~/.spack/source_cache
   build_jobs: 4
+  build_stage:
   db_lock_timeout: 10
+  extensions:
+  install_tree:
+    projections:
+      all: '{name}/{version}/{compiler.name}/{hash}'
+    root: 
+  module_roots:
+    tcl: 
+  source_cache: ~/.spack/source_cache    
+  template_dirs:
+  - $spack/templates

--- a/sysconfigs/daint/packages.yaml
+++ b/sysconfigs/daint/packages.yaml
@@ -2,241 +2,420 @@ packages:
   all:
         # default compilers defined by the system
         # these reflect the current installed PE
-        compiler: [pgi@20.1.1, pgi@20.1.0, gcc@9.3.0, gcc@8.3.0, gcc@8.1.0, cce@10.0.2, intel@19.1.1.217, intel@19.0.1.144]
-        providers:
-            mpi: [mpich]
+    compiler: [pgi@20.1.1, pgi@20.1.0, gcc@9.3.0, gcc@8.3.0, gcc@8.1.0, cce@10.0.2,
+      intel@19.1.1.217, intel@19.0.1.144]
+    providers:
+      mpi: [mpich]
             # if the mpich package support +cuda in the future it needs to be put there
-            mpicuda: [mpich]
-            mkl: [intel-mkl]
-            blas: [cray-libsci_acc, cray-libsci, intel-mkl]
-            scalapack: [cray-libsci_acc, cray-libsci, intel-mkl]
-            pkgconfig: [pkg-config]
-    autoconf:
-        paths:
-             autoconf@2.69%gcc: /usr
-    bison:
-      paths:
-        bison@3.0.4%gcc: /usr
-    automake:
-        paths:
-             automake@1.15.1%gcc: /usr
-    binutils:
-        variants: +gold~headers+libiberty+nls~plugin
-        paths:
-             binutils@2.32: /usr
-    bzip2:
-        paths:
-             bzip2@1.0.6: /usr
-    cosmo:
-      variants: cuda_arch=60 cosmo_target=gpu slave=daint
-      version: [master]
-      compiler: [pgi]
-    gridtools:
-      variants: +cuda cuda_arch=60
-      compiler: [gcc]
-    cosmo-dycore:
-      variants: slave=daint +cuda cuda_arch=60 data_path=/scratch/snx3000/jenkins/data/cosmo/ slurm_args= "'-C gpu -p normal -A g110 -N {0}'"
-      compiler: [gcc@8.3.0]
-    cmake:
-        paths:
-          cmake@3.14.5%gcc: /apps/daint/UES/jenkins/7.0.UP01/gpu/easybuild/software/CMake/3.14.5
-          cmake@3.14.5%pgi: /apps/daint/UES/jenkins/7.0.UP01/gpu/easybuild/software/CMake/3.14.5
-          cmake@3.18.1%gcc: /apps/daint/UES/jenkins/7.0.UP01/gpu/easybuild/software/CMake/3.18.1
-          cmake@3.18.1%pgi: /apps/daint/UES/jenkins/7.0.UP01/gpu/easybuild/software/CMake/3.18.1
-        buildable: false
-        variants: ~doc+ncurses+openssl~ownlibs~qt
-    cp2k:
-        variants: blas=mkl ~elpa+libxc+mpi+openmp~pexsi~plumed smm=libxsmm
-    cray-libsci:
-        buildable: false
-        modules:
-            cray-libsci@20.06.1%gcc:   cray-libsci
-            cray-libsci@20.06.1%intel: cray-libsci
-            cray-libsci@20.06.1%cce:   cray-libsci
-            cray-libsci@20.06.1%pgi:   cray-libsci
-    cray-libsci_acc:
-        buildable: false
-        modules:
-            cray-libsci_acc@20.06.1%gcc:   cray-libsci_acc/20.06.1
-            cray-libsci_acc@20.06.1%intel: cray-libsci_acc/20.06.1
-            cray-libsci_acc@20.06.1%cce:   cray-libsci_acc/20.06.1
-            cray-libsci_acc@20.06.1%pgi:   cray-libsci_acc/20.06.1
-    cuda:
-        modules:
-          cuda@10.2%gcc: cudatoolkit/10.2.89_3.28-7.0.2.1_2.17__g52c0314
-        version: ['10.2']
-    curl:
-        paths:
-             curl@7.60.0: /usr
-    diffutils:
-        paths:
-             diffutils@3.6: /usr
-    elpa:
-        variants: +openmp +optflags
-
-    fftw:
-        buildable: false
-        modules:
-            fftw@3.3.8.7%gcc+openmp:   cray-fftw/3.3.8.7
-            fftw@3.3.8.7%intel+openmp: cray-fftw/3.3.8.7
-            fftw@3.3.8.7%cce+openmp:   cray-fftw/3.3.8.7
-            fftw@3.3.8.7%pgi+openmp:   cray-fftw/3.3.8.7
-    gawk:
-        paths:
-             gawk@4.2.1: /usr
-    gettext:
-        paths:
-             gettext@0.19.8.1: /usr
-    gromacs:
-        variants: build_type=Release +mpi +cuda
-    hdf5:
-        buildable: false
-        modules:
-            hdf5@1.12.0.0%intel~mpi+hl: cray-hdf5/1.12.0.0
-            hdf5@1.12.0.0%gcc~mpi+hl:   cray-hdf5/1.12.0.0
-            hdf5@1.12.0.0%cce~mpi+hl:   cray-hdf5/1.12.0.0
-            hdf5@1.12.0.0%pgi~mpi+hl:   cray-hdf5/1.12.0.0
-            hdf5@1.12.0.0%intel+mpi+hl: cray-hdf5-parallel/1.12.0.0
-            hdf5@1.12.0.0%gcc+mpi+hl:   cray-hdf5-parallel/1.12.0.0
-            hdf5@1.12.0.0%cce+mpi+hl:   cray-hdf5-parallel/1.12.0.0
-            hdf5@1.12.0.0%pgi+mpi+hl:   cray-hdf5-parallel/1.12.0.0
-            hdf5@1.12.0.0%intel~mpi+hl+fortran: cray-hdf5/1.12.0.0
-            hdf5@1.12.0.0%gcc~mpi+hl+fortran:   cray-hdf5/1.12.0.0
-            hdf5@1.12.0.0%cce~mpi+hl+fortran:   cray-hdf5/1.12.0.0
-            hdf5@1.12.0.0%pgi~mpi+hl+fortran:   cray-hdf5/1.12.0.0
-            hdf5@1.12.0.0%intel+mpi+hl+fortran: cray-hdf5-parallel/1.12.0.0
-            hdf5@1.12.0.0%gcc+mpi+hl+fortran:   cray-hdf5-parallel/1.12.0.0
-            hdf5@1.12.0.0%cce+mpi+hl+fortran:   cray-hdf5-parallel/1.12.0.0
-            hdf5@1.12.0.0%pgi+mpi+hl+fortran:   cray-hdf5-parallel/1.12.0.0
-    hwloc:
-        variants: +cuda
-    intel-mkl:
-        buildable: false
-        paths:
-            intel-mkl@2019.1.144%intel+ilp64 threads=tbb:  /opt/intel
-            intel-mkl@2019.1.144%gcc+ilp64 threads=tbb:    /opt/intel
-            intel-mkl@2019.1.144%cce+ilp64 threads=tbb:    /opt/intel
-            intel-mkl@2019.1.144%intel+ilp64 threads=openmp:  /opt/intel
-            intel-mkl@2019.1.144%gcc+ilp64 threads=openmp:    /opt/intel
-            intel-mkl@2019.1.144%cce+ilp64 threads=openmp:    /opt/intel
-            intel-mkl@2019.1.144%intel~ilp64 threads=none: /opt/intel
-            intel-mkl@2019.1.144%gcc~ilp64 threads=none:   /opt/intel
-            intel-mkl@2019.1.144%cce~ilp64 threads=none:   /opt/intel
-    int2lm:
-        variants: slave=daint
-    int2lm-org:
-        variants: slave=daint
-    libjpeg:
-        paths:
-            libjpeg%gcc: /usr
-    libtool:
-        paths:
-             libtool@2.4.6%gcc: /usr
-    libxml2:
-        paths:
-             libxml2@2.9.7%gcc: /usr
-    lz4:
-        paths:
-             lz4@1.8.0: /usr
-    m4:
-        paths:
-             m4@1.4.18%gcc: /usr
-    mpich:
-        buildable: false
-        modules:
-            mpich@3.2%gcc:   cray-mpich/7.7.15
-            mpich@3.2%intel: cray-mpich/7.7.15
-            mpich@3.2%cce:   cray-mpich/7.7.15
-            mpich@3.2%pgi:   cray-mpich/7.7.15
-    netcdf-c:
-        buildable: false
-        modules:
-            netcdf-c@4.7.4.0%gcc+parallel-netcdf+mpi:   cray-netcdf-hdf5parallel/4.7.4.0
-            netcdf-c@4.7.4.0%intel+parallel-netcdf+mpi: cray-netcdf-hdf5parallel/4.7.4.0
-            netcdf-c@4.7.4.0%cce+parallel-netcdf+mpi:   cray-netcdf-hdf5parallel/4.7.4.0
-            netcdf-c@4.7.4.0%pgi+parallel-netcdf+mpi:   cray-netcdf-hdf5parallel/4.7.4.0
-            netcdf-c@4.7.4.0%gcc~parallel-netcdf~mpi:   cray-netcdf/4.7.4.0
-            netcdf-c@4.7.4.0%intel~parallel-netcdf~mpi: cray-netcdf/4.7.4.0
-            netcdf-c@4.7.4.0%cce~parallel-netcdf~mpi:   cray-netcdf/4.7.4.0
-            netcdf-c@4.7.4.0%pgi~parallel-netcdf~mpi:   cray-netcdf/4.7.4.0
-    netcdf-fortran:
-        buildable: false
-        modules:
-            netcdf-fortran@4.7.4.0%gcc+mpi:   cray-netcdf-hdf5parallel/4.7.4.0
-            netcdf-fortran@4.7.4.0%intel+mpi: cray-netcdf-hdf5parallel/4.7.4.0
-            netcdf-fortran@4.7.4.0%cce+mpi:   cray-netcdf-hdf5parallel/4.7.4.0
-            netcdf-fortran@4.7.4.0%pgi+mpi:   cray-netcdf-hdf5parallel/4.7.4.0
-    netcdf-cxx4:
-        buildable: false
-        modules:
-            netcdf-cxx4@4.7.4.0%gcc:   cray-netcdf/4.7.4.0
-        paths:
-            netcdf-cxx4@4.7.4.0%gcc: /opt/cray/pe/netcdf/4.7.4.0/gnu/8.2/
-    netlib-scalapack:
-        variants: build_type=Release
-    netlib-lapack:
-        variants: build_type=Release +external-blas+lapacke
-    openblas:
-        variants: +pic +shared threads=openmp ~virtual_machine
-    openssl:
-        paths:
-            openssl@1.1.0i: /usr
-    openjdk:
-        paths:
-            openjdk@11.0.7%gcc: /usr/lib64/jvm/java-11-openjdk
-    papi:
-        buildable: false
-        modules:
-            papi@6.0.0.2%gcc:   papi/6.0.0.2
-            papi@6.0.0.2%intel: papi/6.0.0.2
-            papi@6.0.0.2%cce:   papi/6.0.0.2
-            papi@6.0.0.2%pgi:   papi/6.0.0.2
-    perl:
-        paths:
-             perl@5.26.1: /usr
-    pkg-config:
-      paths:
-             pkg-config@0.29.2: /usr
-    petsc:
-         buildable: false
-         modules:
-            petsc@3.13.3.0%gcc~complex~int64:    cray-petsc/3.13.3.0
-            petsc@3.13.3.0%intel~complex~int64:  cray-petsc/3.13.3.0
-            petsc@3.13.3.0%cce~complex~int64:    cray-petsc/3.13.3.0
-            petsc@3.13.3.0%pgi~complex~int64:    cray-petsc/3.13.3.0
-            petsc@3.13.3.0%gcc+complex~int64:    cray-petsc-complex/3.13.3.0
-            petsc@3.13.3.0%intel+complex~int64:  cray-petsc-complex/3.13.3.0
-            petsc@3.13.3.0%cce+complex~int64:    cray-petsc-complex/3.13.3.0
-            petsc@3.13.3.0%pgi+complex~int64:    cray-petsc-complex/3.13.3.0
-            petsc@3.13.3.0%gcc~complex+int64:    cray-petsc-64/3.13.3.0
-            petsc@3.13.3.0%intel~complex+int64:  cray-petsc-64/3.13.3.0
-            petsc@3.13.3.0%cce~complex+int64:    cray-petsc-64/3.13.3.0
-            petsc@3.13.3.0%pgi~complex+int64:    cray-petsc-64/3.13.3.0
-            petsc@3.13.3.0%gcc+complex+int64:    cray-petsc-complex-64/3.13.3.0
-            petsc@3.13.3.0%intel+complex+int64:  cray-petsc-complex-64/3.13.3.0
-            petsc@3.13.3.0%cce+complex+int64:    cray-petsc-complex-64/3.13.3.0
-            petsc@3.13.3.0%pgi+complex+int64:    cray-petsc-complex-64/3.13.3.0
-    quantum-espresso:
-        variants: ~elpa +mpi +openmp
-    readline:
-        paths:
-            readline@7.0: /usr
-    slurm:
+      mpicuda: [mpich]
+      mkl: [intel-mkl]
+      blas: [cray-libsci_acc, cray-libsci, intel-mkl]
+      scalapack: [cray-libsci_acc, cray-libsci, intel-mkl]
+      pkgconfig: [pkg-config]
+  autoconf:
+    externals:
+    - spec: autoconf@2.69%gcc
+      prefix: /usr
+  bison:
+    externals:
+    - spec: bison@3.0.4%gcc
+      prefix: /usr
+  automake:
+    externals:
+    - spec: automake@1.15.1%gcc
+      prefix: /usr
+  binutils:
+    variants: +gold~headers+libiberty+nls~plugin
+    externals:
+    - spec: binutils@2.32
+      prefix: /usr
+  bzip2:
+    externals:
+    - spec: bzip2@1.0.6
+      prefix: /usr
+  cosmo:
+    variants: cuda_arch=60 cosmo_target=gpu slave=daint
+    version: [master]
+    compiler: [pgi]
+  gridtools:
+    variants: +cuda cuda_arch=60
+    compiler: [gcc]
+  cosmo-dycore:
+    variants: slave=daint +cuda cuda_arch=60 data_path=/scratch/snx3000/jenkins/data/cosmo/
+      slurm_args= "'-C gpu -p normal -A g110 -N {0}'"
+    compiler: [gcc@8.3.0]
+  cmake:
+    buildable: false
+    variants: ~doc+ncurses+openssl~ownlibs~qt
+    externals:
+    - spec: cmake@3.14.5%gcc
+      prefix: /apps/daint/UES/jenkins/7.0.UP01/gpu/easybuild/software/CMake/3.14.5
+    - spec: cmake@3.14.5%pgi
+      prefix: /apps/daint/UES/jenkins/7.0.UP01/gpu/easybuild/software/CMake/3.14.5
+    - spec: cmake@3.18.1%gcc
+      prefix: /apps/daint/UES/jenkins/7.0.UP01/gpu/easybuild/software/CMake/3.18.1
+    - spec: cmake@3.18.1%pgi
+      prefix: /apps/daint/UES/jenkins/7.0.UP01/gpu/easybuild/software/CMake/3.18.1
+  cp2k:
+    variants: blas=mkl ~elpa+libxc+mpi+openmp~pexsi~plumed smm=libxsmm
+  cray-libsci:
+    buildable: false
+    externals:
+    - spec: cray-libsci@20.06.1%gcc
       modules:
-        slurm@20.02.2-1%gcc: slurm/20.02.2-1
-    tar:
-        paths:
-             tar@1.30.0: /bin
-    trilinos:
-        buildable: false
-        modules:
-            trilinos@12.18.1.1%gcc:   cray-trilinos/12.18.1.1
-            trilinos@12.18.1.1%intel: cray-trilinos/12.18.1.1
-            trilinos@12.18.1.1%cce:   cray-trilinos/12.18.1.1
-            trilinos@12.18.1.1%pgi:   cray-trilinos/12.18.1.1
-    xz:
-        paths:
-             xz@5.2.3: /usr
-    zlib:
-        paths:
-             zlib@1.2.11: /usr
+      - cray-libsci
+    - spec: cray-libsci@20.06.1%intel
+      modules:
+      - cray-libsci
+    - spec: cray-libsci@20.06.1%cce
+      modules:
+      - cray-libsci
+    - spec: cray-libsci@20.06.1%pgi
+      modules:
+      - cray-libsci
+  cray-libsci_acc:
+    buildable: false
+    externals:
+    - spec: cray-libsci_acc@20.06.1%gcc
+      modules:
+      - cray-libsci_acc/20.06.1
+    - spec: cray-libsci_acc@20.06.1%intel
+      modules:
+      - cray-libsci_acc/20.06.1
+    - spec: cray-libsci_acc@20.06.1%cce
+      modules:
+      - cray-libsci_acc/20.06.1
+    - spec: cray-libsci_acc@20.06.1%pgi
+      modules:
+      - cray-libsci_acc/20.06.1
+  cuda:
+    version: ['10.2']
+    externals:
+    - spec: cuda@10.2%gcc
+      modules:
+      - cudatoolkit/10.2.89_3.28-7.0.2.1_2.17__g52c0314
+  curl:
+    externals:
+    - spec: curl@7.60.0
+      prefix: /usr
+  diffutils:
+    externals:
+    - spec: diffutils@3.6
+      prefix: /usr
+  elpa:
+    variants: +openmp +optflags
+
+  fftw:
+    buildable: false
+    externals:
+    - spec: fftw@3.3.8.7%gcc+openmp
+      modules:
+      - cray-fftw/3.3.8.7
+    - spec: fftw@3.3.8.7%intel+openmp
+      modules:
+      - cray-fftw/3.3.8.7
+    - spec: fftw@3.3.8.7%cce+openmp
+      modules:
+      - cray-fftw/3.3.8.7
+    - spec: fftw@3.3.8.7%pgi+openmp
+      modules:
+      - cray-fftw/3.3.8.7
+  gawk:
+    externals:
+    - spec: gawk@4.2.1
+      prefix: /usr
+  gettext:
+    externals:
+    - spec: gettext@0.19.8.1
+      prefix: /usr
+  gromacs:
+    variants: build_type=Release +mpi +cuda
+  hdf5:
+    buildable: false
+    externals:
+    - spec: hdf5@1.12.0.0%intel~mpi+hl
+      modules:
+      - cray-hdf5/1.12.0.0
+    - spec: hdf5@1.12.0.0%gcc~mpi+hl
+      modules:
+      - cray-hdf5/1.12.0.0
+    - spec: hdf5@1.12.0.0%cce~mpi+hl
+      modules:
+      - cray-hdf5/1.12.0.0
+    - spec: hdf5@1.12.0.0%pgi~mpi+hl
+      modules:
+      - cray-hdf5/1.12.0.0
+    - spec: hdf5@1.12.0.0%intel+mpi+hl
+      modules:
+      - cray-hdf5-parallel/1.12.0.0
+    - spec: hdf5@1.12.0.0%gcc+mpi+hl
+      modules:
+      - cray-hdf5-parallel/1.12.0.0
+    - spec: hdf5@1.12.0.0%cce+mpi+hl
+      modules:
+      - cray-hdf5-parallel/1.12.0.0
+    - spec: hdf5@1.12.0.0%pgi+mpi+hl
+      modules:
+      - cray-hdf5-parallel/1.12.0.0
+    - spec: hdf5@1.12.0.0%intel~mpi+hl+fortran
+      modules:
+      - cray-hdf5/1.12.0.0
+    - spec: hdf5@1.12.0.0%gcc~mpi+hl+fortran
+      modules:
+      - cray-hdf5/1.12.0.0
+    - spec: hdf5@1.12.0.0%cce~mpi+hl+fortran
+      modules:
+      - cray-hdf5/1.12.0.0
+    - spec: hdf5@1.12.0.0%pgi~mpi+hl+fortran
+      modules:
+      - cray-hdf5/1.12.0.0
+    - spec: hdf5@1.12.0.0%intel+mpi+hl+fortran
+      modules:
+      - cray-hdf5-parallel/1.12.0.0
+    - spec: hdf5@1.12.0.0%gcc+mpi+hl+fortran
+      modules:
+      - cray-hdf5-parallel/1.12.0.0
+    - spec: hdf5@1.12.0.0%cce+mpi+hl+fortran
+      modules:
+      - cray-hdf5-parallel/1.12.0.0
+    - spec: hdf5@1.12.0.0%pgi+mpi+hl+fortran
+      modules:
+      - cray-hdf5-parallel/1.12.0.0
+  hwloc:
+    variants: +cuda
+  intel-mkl:
+    buildable: false
+    externals:
+    - spec: intel-mkl@2019.1.144%intel+ilp64 threads=tbb
+      prefix: /opt/intel
+    - spec: intel-mkl@2019.1.144%gcc+ilp64 threads=tbb
+      prefix: /opt/intel
+    - spec: intel-mkl@2019.1.144%cce+ilp64 threads=tbb
+      prefix: /opt/intel
+    - spec: intel-mkl@2019.1.144%intel+ilp64 threads=openmp
+      prefix: /opt/intel
+    - spec: intel-mkl@2019.1.144%gcc+ilp64 threads=openmp
+      prefix: /opt/intel
+    - spec: intel-mkl@2019.1.144%cce+ilp64 threads=openmp
+      prefix: /opt/intel
+    - spec: intel-mkl@2019.1.144%intel~ilp64 threads=none
+      prefix: /opt/intel
+    - spec: intel-mkl@2019.1.144%gcc~ilp64 threads=none
+      prefix: /opt/intel
+    - spec: intel-mkl@2019.1.144%cce~ilp64 threads=none
+      prefix: /opt/intel
+  int2lm:
+    variants: slave=daint
+  int2lm-org:
+    variants: slave=daint
+  libjpeg:
+    externals:
+    - spec: libjpeg%gcc
+      prefix: /usr
+  libtool:
+    externals:
+    - spec: libtool@2.4.6%gcc
+      prefix: /usr
+  libxml2:
+    externals:
+    - spec: libxml2@2.9.7%gcc
+      prefix: /usr
+  lz4:
+    externals:
+    - spec: lz4@1.8.0
+      prefix: /usr
+  m4:
+    externals:
+    - spec: m4@1.4.18%gcc
+      prefix: /usr
+  mpich:
+    buildable: false
+    externals:
+    - spec: mpich@3.2%gcc
+      modules:
+      - cray-mpich/7.7.15
+    - spec: mpich@3.2%intel
+      modules:
+      - cray-mpich/7.7.15
+    - spec: mpich@3.2%cce
+      modules:
+      - cray-mpich/7.7.15
+    - spec: mpich@3.2%pgi
+      modules:
+      - cray-mpich/7.7.15
+  netcdf-c:
+    buildable: false
+    externals:
+    - spec: netcdf-c@4.7.4.0%gcc+parallel-netcdf+mpi
+      modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+    - spec: netcdf-c@4.7.4.0%intel+parallel-netcdf+mpi
+      modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+    - spec: netcdf-c@4.7.4.0%cce+parallel-netcdf+mpi
+      modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+    - spec: netcdf-c@4.7.4.0%pgi+parallel-netcdf+mpi
+      modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+    - spec: netcdf-c@4.7.4.0%gcc~parallel-netcdf~mpi
+      modules:
+      - cray-netcdf/4.7.4.0
+    - spec: netcdf-c@4.7.4.0%intel~parallel-netcdf~mpi
+      modules:
+      - cray-netcdf/4.7.4.0
+    - spec: netcdf-c@4.7.4.0%cce~parallel-netcdf~mpi
+      modules:
+      - cray-netcdf/4.7.4.0
+    - spec: netcdf-c@4.7.4.0%pgi~parallel-netcdf~mpi
+      modules:
+      - cray-netcdf/4.7.4.0
+  netcdf-fortran:
+    buildable: false
+    externals:
+    - spec: netcdf-fortran@4.7.4.0%gcc
+      modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+    - spec: netcdf-fortran@4.7.4.0%intel
+      modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+    - spec: netcdf-fortran@4.7.4.0%cce
+      modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+    - spec: netcdf-fortran@4.7.4.0%pgi
+      modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+  netcdf-cxx4:
+    buildable: false
+    externals:
+    - spec: netcdf-cxx4@4.7.4.0%gcc
+      prefix: /opt/cray/pe/netcdf/4.7.4.0/gnu/8.2/
+    - spec: netcdf-cxx4@4.7.4.0%gcc
+      modules:
+      - cray-netcdf/4.7.4.0
+  netlib-scalapack:
+    variants: build_type=Release
+  netlib-lapack:
+    variants: build_type=Release +external-blas+lapacke
+  openblas:
+    variants: +pic +shared threads=openmp ~virtual_machine
+  openssl:
+    externals:
+    - spec: openssl@1.1.0i
+      prefix: /usr
+  openjdk:
+    externals:
+    - spec: openjdk@11.0.7%gcc
+      prefix: /usr/lib64/jvm/java-11-openjdk
+  papi:
+    buildable: false
+    externals:
+    - spec: papi@6.0.0.2%gcc
+      modules:
+      - papi/6.0.0.2
+    - spec: papi@6.0.0.2%intel
+      modules:
+      - papi/6.0.0.2
+    - spec: papi@6.0.0.2%cce
+      modules:
+      - papi/6.0.0.2
+    - spec: papi@6.0.0.2%pgi
+      modules:
+      - papi/6.0.0.2
+  perl:
+    externals:
+    - spec: perl@5.26.1
+      prefix: /usr
+  pkg-config:
+    externals:
+    - spec: pkg-config@0.29.2
+      prefix: /usr
+  petsc:
+    buildable: false
+    externals:
+    - spec: petsc@3.13.3.0%gcc~complex~int64
+      modules:
+      - cray-petsc/3.13.3.0
+    - spec: petsc@3.13.3.0%intel~complex~int64
+      modules:
+      - cray-petsc/3.13.3.0
+    - spec: petsc@3.13.3.0%cce~complex~int64
+      modules:
+      - cray-petsc/3.13.3.0
+    - spec: petsc@3.13.3.0%pgi~complex~int64
+      modules:
+      - cray-petsc/3.13.3.0
+    - spec: petsc@3.13.3.0%gcc+complex~int64
+      modules:
+      - cray-petsc-complex/3.13.3.0
+    - spec: petsc@3.13.3.0%intel+complex~int64
+      modules:
+      - cray-petsc-complex/3.13.3.0
+    - spec: petsc@3.13.3.0%cce+complex~int64
+      modules:
+      - cray-petsc-complex/3.13.3.0
+    - spec: petsc@3.13.3.0%pgi+complex~int64
+      modules:
+      - cray-petsc-complex/3.13.3.0
+    - spec: petsc@3.13.3.0%gcc~complex+int64
+      modules:
+      - cray-petsc-64/3.13.3.0
+    - spec: petsc@3.13.3.0%intel~complex+int64
+      modules:
+      - cray-petsc-64/3.13.3.0
+    - spec: petsc@3.13.3.0%cce~complex+int64
+      modules:
+      - cray-petsc-64/3.13.3.0
+    - spec: petsc@3.13.3.0%pgi~complex+int64
+      modules:
+      - cray-petsc-64/3.13.3.0
+    - spec: petsc@3.13.3.0%gcc+complex+int64
+      modules:
+      - cray-petsc-complex-64/3.13.3.0
+    - spec: petsc@3.13.3.0%intel+complex+int64
+      modules:
+      - cray-petsc-complex-64/3.13.3.0
+    - spec: petsc@3.13.3.0%cce+complex+int64
+      modules:
+      - cray-petsc-complex-64/3.13.3.0
+    - spec: petsc@3.13.3.0%pgi+complex+int64
+      modules:
+      - cray-petsc-complex-64/3.13.3.0
+  quantum-espresso:
+    variants: ~elpa +mpi +openmp
+  readline:
+    externals:
+    - spec: readline@7.0
+      prefix: /usr
+  slurm:
+    externals:
+    - spec: slurm@20.02.2-1%gcc
+      modules:
+      - slurm/20.02.2-1
+  tar:
+    externals:
+    - spec: tar@1.30.0
+      prefix: /bin
+  trilinos:
+    buildable: false
+    externals:
+    - spec: trilinos@12.18.1.1%gcc
+      modules:
+      - cray-trilinos/12.18.1.1
+    - spec: trilinos@12.18.1.1%intel
+      modules:
+      - cray-trilinos/12.18.1.1
+    - spec: trilinos@12.18.1.1%cce
+      modules:
+      - cray-trilinos/12.18.1.1
+    - spec: trilinos@12.18.1.1%pgi
+      modules:
+      - cray-trilinos/12.18.1.1
+  xz:
+    externals:
+    - spec: xz@5.2.3
+      prefix: /usr
+  zlib:
+    externals:
+    - spec: zlib@1.2.11
+      prefix: /usr

--- a/sysconfigs/daint/packages.yaml
+++ b/sysconfigs/daint/packages.yaml
@@ -1,245 +1,421 @@
-# Based on NERSC Cori config
-# These package should be upgraded whenever there is a CDT or PE upgrade
 packages:
-    all:
+  all:
         # default compilers defined by the system
         # these reflect the current installed PE
-        compiler: [pgi@20.1.1, pgi@20.1.0, gcc@9.3.0, gcc@8.1.0, cce@10.0.2, intel@19.1.1.217, intel@19.0.1.144]
-        providers:
-            mpi: [mpich]
+    compiler: [pgi@20.1.1, pgi@20.1.0, gcc@9.3.0, gcc@8.1.0, cce@10.0.2, intel@19.1.1.217,
+      intel@19.0.1.144]
+    providers:
+      mpi: [mpich]
             # if the mpich package support +cuda in the future it needs to be put there
-            mpicuda: [mpich]
-            mkl: [intel-mkl]
-            blas: [cray-libsci_acc, cray-libsci, intel-mkl]
-            scalapack: [cray-libsci_acc, cray-libsci, intel-mkl]
-            pkgconfig: [pkg-config]
-    autoconf:
-        paths:
-             autoconf@2.69%gcc: /usr
-    bison:
-      paths:
-        bison@3.0.4%gcc: /usr
-    automake:
-        paths:
-             automake@1.15.1%gcc: /usr
-    binutils:
-        variants: +gold~headers+libiberty+nls~plugin
-        paths:
-             binutils@2.32: /usr
-    bzip2:
-        paths:
-             bzip2@1.0.6: /usr
-    cosmo:
-      variants: cuda_arch=60 cosmo_target=gpu slave=daint
-      version: [master]
-      compiler: [pgi]
-    gridtools:
-      variants: +cuda cuda_arch=60
-      compiler: [gcc]
-    cosmo-dycore:
-      variants: slave=daint +cuda cuda_arch=60 data_path=/scratch/snx3000/jenkins/data/cosmo/ slurm_args= "'-C gpu -p normal -A g110 -N {0}'"
-      compiler: [gcc]
-    cmake:
-        paths:
-          cmake@3.14.5%gcc: /apps/daint/UES/jenkins/7.0.UP01/gpu/easybuild/software/CMake/3.14.5
-          cmake@3.14.5%pgi: /apps/daint/UES/jenkins/7.0.UP01/gpu/easybuild/software/CMake/3.14.5
-          cmake@3.18.1%gcc: /apps/daint/UES/jenkins/7.0.UP01/gpu/easybuild/software/CMake/3.18.1
-          cmake@3.18.1%pgi: /apps/daint/UES/jenkins/7.0.UP01/gpu/easybuild/software/CMake/3.18.1
-        buildable: false
-        variants: ~doc+ncurses+openssl~ownlibs~qt
-    cp2k:
-        variants: blas=mkl ~elpa+libxc+mpi+openmp~pexsi~plumed smm=libxsmm
-    cray-libsci:
-        buildable: false
-        modules:
-            cray-libsci@20.06.1%gcc:   cray-libsci
-            cray-libsci@20.06.1%intel: cray-libsci
-            cray-libsci@20.06.1%cce:   cray-libsci
-            cray-libsci@20.06.1%pgi:   cray-libsci
-    cray-libsci_acc:
-        buildable: false
-        modules:
-            cray-libsci_acc@20.06.1%gcc:   cray-libsci_acc/20.06.1
-            cray-libsci_acc@20.06.1%intel: cray-libsci_acc/20.06.1
-            cray-libsci_acc@20.06.1%cce:   cray-libsci_acc/20.06.1
-            cray-libsci_acc@20.06.1%pgi:   cray-libsci_acc/20.06.1
-    cuda:
-        modules:
-          cuda@10.2%gcc: cudatoolkit/10.2.89_3.28-7.0.2.1_2.17__g52c0314
-        version: ['10.2']
-    curl:
-        paths:
-             curl@7.60.0: /usr
-    diffutils:
-        paths:
-             diffutils@3.6: /usr
-    elpa:
-        variants: +openmp +optflags
-
-    fftw:
-        buildable: false
-        modules:
-            fftw@3.3.8.7%gcc+openmp:   cray-fftw/3.3.8.7
-            fftw@3.3.8.7%intel+openmp: cray-fftw/3.3.8.7
-            fftw@3.3.8.7%cce+openmp:   cray-fftw/3.3.8.7
-            fftw@3.3.8.7%pgi+openmp:   cray-fftw/3.3.8.7
-    gawk:
-        paths:
-             gawk@4.2.1: /usr
-    gettext:
-        paths:
-             gettext@0.19.8.1: /usr
-    gromacs:
-        variants: build_type=Release +mpi +cuda
-    hdf5:
-        buildable: false
-        modules:
-            hdf5@1.12.0.0%intel~mpi+hl: cray-hdf5/1.12.0.0
-            hdf5@1.12.0.0%gcc~mpi+hl:   cray-hdf5/1.12.0.0
-            hdf5@1.12.0.0%cce~mpi+hl:   cray-hdf5/1.12.0.0
-            hdf5@1.12.0.0%pgi~mpi+hl:   cray-hdf5/1.12.0.0
-            hdf5@1.12.0.0%intel+mpi+hl: cray-hdf5-parallel/1.12.0.0
-            hdf5@1.12.0.0%gcc+mpi+hl:   cray-hdf5-parallel/1.12.0.0
-            hdf5@1.12.0.0%cce+mpi+hl:   cray-hdf5-parallel/1.12.0.0
-            hdf5@1.12.0.0%pgi+mpi+hl:   cray-hdf5-parallel/1.12.0.0
-            hdf5@1.12.0.0%intel~mpi+hl+fortran: cray-hdf5/1.12.0.0
-            hdf5@1.12.0.0%gcc~mpi+hl+fortran:   cray-hdf5/1.12.0.0
-            hdf5@1.12.0.0%cce~mpi+hl+fortran:   cray-hdf5/1.12.0.0
-            hdf5@1.12.0.0%pgi~mpi+hl+fortran:   cray-hdf5/1.12.0.0
-            hdf5@1.12.0.0%intel+mpi+hl+fortran: cray-hdf5-parallel/1.12.0.0
-            hdf5@1.12.0.0%gcc+mpi+hl+fortran:   cray-hdf5-parallel/1.12.0.0
-            hdf5@1.12.0.0%cce+mpi+hl+fortran:   cray-hdf5-parallel/1.12.0.0
-            hdf5@1.12.0.0%pgi+mpi+hl+fortran:   cray-hdf5-parallel/1.12.0.0
-    hwloc:
-        variants: +cuda
-    intel-mkl:
-        buildable: false
-        paths:
-            intel-mkl@2019.1.144%intel+ilp64 threads=tbb:  /opt/intel
-            intel-mkl@2019.1.144%gcc+ilp64 threads=tbb:    /opt/intel
-            intel-mkl@2019.1.144%cce+ilp64 threads=tbb:    /opt/intel
-            intel-mkl@2019.1.144%intel+ilp64 threads=openmp:  /opt/intel
-            intel-mkl@2019.1.144%gcc+ilp64 threads=openmp:    /opt/intel
-            intel-mkl@2019.1.144%cce+ilp64 threads=openmp:    /opt/intel
-            intel-mkl@2019.1.144%intel~ilp64 threads=none: /opt/intel
-            intel-mkl@2019.1.144%gcc~ilp64 threads=none:   /opt/intel
-            intel-mkl@2019.1.144%cce~ilp64 threads=none:   /opt/intel
-    int2lm:
-        variants: slave=daint
-    int2lm-org:
-        variants: slave=daint
-    libjpeg:
-        paths:
-            libjpeg%gcc: /usr
-    libtool:
-        paths:
-             libtool@2.4.6%gcc: /usr
-    libxml2:
-        paths:
-             libxml2@2.9.7%gcc: /usr
-    lz4:
-        paths:
-             lz4@1.8.0: /usr
-    m4:
-        paths:
-             m4@1.4.18%gcc: /usr
-    mpich:
-        buildable: false
-        modules:
-            mpich@3.2%gcc:   cray-mpich/7.7.15
-            mpich@3.2%intel: cray-mpich/7.7.15
-            mpich@3.2%cce:   cray-mpich/7.7.15
-            mpich@3.2%pgi:   cray-mpich/7.7.15
-    netcdf-c:
-        buildable: false
-        modules:
-            netcdf-c@4.7.4.0%gcc+parallel-netcdf+mpi:   cray-netcdf-hdf5parallel/4.7.4.0
-            netcdf-c@4.7.4.0%intel+parallel-netcdf+mpi: cray-netcdf-hdf5parallel/4.7.4.0
-            netcdf-c@4.7.4.0%cce+parallel-netcdf+mpi:   cray-netcdf-hdf5parallel/4.7.4.0
-            netcdf-c@4.7.4.0%pgi+parallel-netcdf+mpi:   cray-netcdf-hdf5parallel/4.7.4.0
-            netcdf-c@4.7.4.0%gcc~parallel-netcdf~mpi:   cray-netcdf/4.7.4.0
-            netcdf-c@4.7.4.0%intel~parallel-netcdf~mpi: cray-netcdf/4.7.4.0
-            netcdf-c@4.7.4.0%cce~parallel-netcdf~mpi:   cray-netcdf/4.7.4.0
-            netcdf-c@4.7.4.0%pgi~parallel-netcdf~mpi:   cray-netcdf/4.7.4.0
-    netcdf-fortran:
-        buildable: false
-        modules:
-            netcdf-fortran@4.7.4.0%gcc+mpi:   cray-netcdf-hdf5parallel/4.7.4.0
-            netcdf-fortran@4.7.4.0%intel+mpi: cray-netcdf-hdf5parallel/4.7.4.0
-            netcdf-fortran@4.7.4.0%cce+mpi:   cray-netcdf-hdf5parallel/4.7.4.0
-            netcdf-fortran@4.7.4.0%pgi+mpi:   cray-netcdf-hdf5parallel/4.7.4.0
-    netcdf-cxx4:
-        buildable: false
-        modules:
-            netcdf-cxx4@4.7.4.0%gcc:   cray-netcdf/4.7.4.0
-        paths:
-            netcdf-cxx4@4.7.4.0%gcc: /opt/cray/pe/netcdf/4.7.4.0/gnu/8.2/
-    netlib-scalapack:
-        variants: build_type=Release
-    netlib-lapack:
-        variants: build_type=Release +external-blas+lapacke
-    openblas:
-        variants: +pic +shared threads=openmp ~virtual_machine
-    openssl:
-        paths:
-            openssl@1.1.0i: /usr
-    openjdk:
-        paths:
-            openjdk@11.0.7%gcc: /usr/lib64/jvm/java-11-openjdk
-    papi:
-        buildable: false
-        modules:
-            papi@6.0.0.2%gcc:   papi/6.0.0.2
-            papi@6.0.0.2%intel: papi/6.0.0.2
-            papi@6.0.0.2%cce:   papi/6.0.0.2
-            papi@6.0.0.2%pgi:   papi/6.0.0.2
-    perl:
-        paths:
-             perl@5.26.1: /usr
-    pkg-config:
-      paths:
-             pkg-config@0.29.2: /usr
-    petsc:
-         buildable: false
-         modules:
-            petsc@3.13.3.0%gcc~complex~int64:    cray-petsc/3.13.3.0
-            petsc@3.13.3.0%intel~complex~int64:  cray-petsc/3.13.3.0
-            petsc@3.13.3.0%cce~complex~int64:    cray-petsc/3.13.3.0
-            petsc@3.13.3.0%pgi~complex~int64:    cray-petsc/3.13.3.0
-            petsc@3.13.3.0%gcc+complex~int64:    cray-petsc-complex/3.13.3.0
-            petsc@3.13.3.0%intel+complex~int64:  cray-petsc-complex/3.13.3.0
-            petsc@3.13.3.0%cce+complex~int64:    cray-petsc-complex/3.13.3.0
-            petsc@3.13.3.0%pgi+complex~int64:    cray-petsc-complex/3.13.3.0
-            petsc@3.13.3.0%gcc~complex+int64:    cray-petsc-64/3.13.3.0
-            petsc@3.13.3.0%intel~complex+int64:  cray-petsc-64/3.13.3.0
-            petsc@3.13.3.0%cce~complex+int64:    cray-petsc-64/3.13.3.0
-            petsc@3.13.3.0%pgi~complex+int64:    cray-petsc-64/3.13.3.0
-            petsc@3.13.3.0%gcc+complex+int64:    cray-petsc-complex-64/3.13.3.0
-            petsc@3.13.3.0%intel+complex+int64:  cray-petsc-complex-64/3.13.3.0
-            petsc@3.13.3.0%cce+complex+int64:    cray-petsc-complex-64/3.13.3.0
-            petsc@3.13.3.0%pgi+complex+int64:    cray-petsc-complex-64/3.13.3.0
-    quantum-espresso:
-        variants: ~elpa +mpi +openmp
-    readline:
-        paths:
-            readline@7.0: /usr
-    slurm:
+      mpicuda: [mpich]
+      mkl: [intel-mkl]
+      blas: [cray-libsci_acc, cray-libsci, intel-mkl]
+      scalapack: [cray-libsci_acc, cray-libsci, intel-mkl]
+      pkgconfig: [pkg-config]
+  autoconf:
+    externals:
+    - spec: autoconf@2.69%gcc
+      prefix: /usr
+  bison:
+    externals:
+    - spec: bison@3.0.4%gcc
+      prefix: /usr
+  automake:
+    externals:
+    - spec: automake@1.15.1%gcc
+      prefix: /usr
+  binutils:
+    variants: +gold~headers+libiberty+nls~plugin
+    externals:
+    - spec: binutils@2.32
+      prefix: /usr
+  bzip2:
+    externals:
+    - spec: bzip2@1.0.6
+      prefix: /usr
+  cosmo:
+    variants: cuda_arch=60 cosmo_target=gpu slave=daint
+    version: [master]
+    compiler: [pgi]
+  gridtools:
+    variants: +cuda cuda_arch=60
+    compiler: [gcc]
+  cosmo-dycore:
+    variants: slave=daint +cuda cuda_arch=60 data_path=/scratch/snx3000/jenkins/data/cosmo/
+      slurm_args= "'-C gpu -p normal -A g110 -N {0}'"
+    compiler: [gcc]
+  cmake:
+    buildable: false
+    variants: ~doc+ncurses+openssl~ownlibs~qt
+    externals:
+    - spec: cmake@3.14.5%gcc
+      prefix: /apps/daint/UES/jenkins/7.0.UP01/gpu/easybuild/software/CMake/3.14.5
+    - spec: cmake@3.14.5%pgi
+      prefix: /apps/daint/UES/jenkins/7.0.UP01/gpu/easybuild/software/CMake/3.14.5
+    - spec: cmake@3.18.1%gcc
+      prefix: /apps/daint/UES/jenkins/7.0.UP01/gpu/easybuild/software/CMake/3.18.1
+    - spec: cmake@3.18.1%pgi
+      prefix: /apps/daint/UES/jenkins/7.0.UP01/gpu/easybuild/software/CMake/3.18.1
+  cp2k:
+    variants: blas=mkl ~elpa+libxc+mpi+openmp~pexsi~plumed smm=libxsmm
+  cray-libsci:
+    buildable: false
+    externals:
+    - spec: cray-libsci@20.06.1%gcc
       modules:
-        slurm@20.02.2-1%gcc: slurm/20.02.2-1
-    tar:
-        paths:
-             tar@1.30.0: /bin
-    trilinos:
-        buildable: false
-        modules:
-            trilinos@12.18.1.1%gcc:   cray-trilinos/12.18.1.1
-            trilinos@12.18.1.1%intel: cray-trilinos/12.18.1.1
-            trilinos@12.18.1.1%cce:   cray-trilinos/12.18.1.1
-            trilinos@12.18.1.1%pgi:   cray-trilinos/12.18.1.1
-    xz:
-        paths:
-             xz@5.2.3: /usr
-    zlib:
-        paths:
-             zlib@1.2.11: /usr
+      - cray-libsci
+    - spec: cray-libsci@20.06.1%intel
+      modules:
+      - cray-libsci
+    - spec: cray-libsci@20.06.1%cce
+      modules:
+      - cray-libsci
+    - spec: cray-libsci@20.06.1%pgi
+      modules:
+      - cray-libsci
+  cray-libsci_acc:
+    buildable: false
+    externals:
+    - spec: cray-libsci_acc@20.06.1%gcc
+      modules:
+      - cray-libsci_acc/20.06.1
+    - spec: cray-libsci_acc@20.06.1%intel
+      modules:
+      - cray-libsci_acc/20.06.1
+    - spec: cray-libsci_acc@20.06.1%cce
+      modules:
+      - cray-libsci_acc/20.06.1
+    - spec: cray-libsci_acc@20.06.1%pgi
+      modules:
+      - cray-libsci_acc/20.06.1
+  cuda:
+    version: ['10.2']
+    externals:
+    - spec: cuda@10.2%gcc
+      modules:
+      - cudatoolkit/10.2.89_3.28-7.0.2.1_2.17__g52c0314
+  curl:
+    externals:
+    - spec: curl@7.60.0
+      prefix: /usr
+  diffutils:
+    externals:
+    - spec: diffutils@3.6
+      prefix: /usr
+  elpa:
+    variants: +openmp +optflags
 
+  fftw:
+    buildable: false
+    externals:
+    - spec: fftw@3.3.8.7%gcc+openmp
+      modules:
+      - cray-fftw/3.3.8.7
+    - spec: fftw@3.3.8.7%intel+openmp
+      modules:
+      - cray-fftw/3.3.8.7
+    - spec: fftw@3.3.8.7%cce+openmp
+      modules:
+      - cray-fftw/3.3.8.7
+    - spec: fftw@3.3.8.7%pgi+openmp
+      modules:
+      - cray-fftw/3.3.8.7
+  gawk:
+    externals:
+    - spec: gawk@4.2.1
+      prefix: /usr
+  gettext:
+    externals:
+    - spec: gettext@0.19.8.1
+      prefix: /usr
+  gromacs:
+    variants: build_type=Release +mpi +cuda
+  hdf5:
+    buildable: false
+    externals:
+    - spec: hdf5@1.12.0.0%intel~mpi+hl
+      modules:
+      - cray-hdf5/1.12.0.0
+    - spec: hdf5@1.12.0.0%gcc~mpi+hl
+      modules:
+      - cray-hdf5/1.12.0.0
+    - spec: hdf5@1.12.0.0%cce~mpi+hl
+      modules:
+      - cray-hdf5/1.12.0.0
+    - spec: hdf5@1.12.0.0%pgi~mpi+hl
+      modules:
+      - cray-hdf5/1.12.0.0
+    - spec: hdf5@1.12.0.0%intel+mpi+hl
+      modules:
+      - cray-hdf5-parallel/1.12.0.0
+    - spec: hdf5@1.12.0.0%gcc+mpi+hl
+      modules:
+      - cray-hdf5-parallel/1.12.0.0
+    - spec: hdf5@1.12.0.0%cce+mpi+hl
+      modules:
+      - cray-hdf5-parallel/1.12.0.0
+    - spec: hdf5@1.12.0.0%pgi+mpi+hl
+      modules:
+      - cray-hdf5-parallel/1.12.0.0
+    - spec: hdf5@1.12.0.0%intel~mpi+hl+fortran
+      modules:
+      - cray-hdf5/1.12.0.0
+    - spec: hdf5@1.12.0.0%gcc~mpi+hl+fortran
+      modules:
+      - cray-hdf5/1.12.0.0
+    - spec: hdf5@1.12.0.0%cce~mpi+hl+fortran
+      modules:
+      - cray-hdf5/1.12.0.0
+    - spec: hdf5@1.12.0.0%pgi~mpi+hl+fortran
+      modules:
+      - cray-hdf5/1.12.0.0
+    - spec: hdf5@1.12.0.0%intel+mpi+hl+fortran
+      modules:
+      - cray-hdf5-parallel/1.12.0.0
+    - spec: hdf5@1.12.0.0%gcc+mpi+hl+fortran
+      modules:
+      - cray-hdf5-parallel/1.12.0.0
+    - spec: hdf5@1.12.0.0%cce+mpi+hl+fortran
+      modules:
+      - cray-hdf5-parallel/1.12.0.0
+    - spec: hdf5@1.12.0.0%pgi+mpi+hl+fortran
+      modules:
+      - cray-hdf5-parallel/1.12.0.0
+  hwloc:
+    variants: +cuda
+  intel-mkl:
+    buildable: false
+    externals:
+    - spec: intel-mkl@2019.1.144%intel+ilp64 threads=tbb
+      prefix: /opt/intel
+    - spec: intel-mkl@2019.1.144%gcc+ilp64 threads=tbb
+      prefix: /opt/intel
+    - spec: intel-mkl@2019.1.144%cce+ilp64 threads=tbb
+      prefix: /opt/intel
+    - spec: intel-mkl@2019.1.144%intel+ilp64 threads=openmp
+      prefix: /opt/intel
+    - spec: intel-mkl@2019.1.144%gcc+ilp64 threads=openmp
+      prefix: /opt/intel
+    - spec: intel-mkl@2019.1.144%cce+ilp64 threads=openmp
+      prefix: /opt/intel
+    - spec: intel-mkl@2019.1.144%intel~ilp64 threads=none
+      prefix: /opt/intel
+    - spec: intel-mkl@2019.1.144%gcc~ilp64 threads=none
+      prefix: /opt/intel
+    - spec: intel-mkl@2019.1.144%cce~ilp64 threads=none
+      prefix: /opt/intel
+  int2lm:
+    variants: slave=daint
+  int2lm-org:
+    variants: slave=daint
+  libjpeg:
+    externals:
+    - spec: libjpeg%gcc
+      prefix: /usr
+  libtool:
+    externals:
+    - spec: libtool@2.4.6%gcc
+      prefix: /usr
+  libxml2:
+    externals:
+    - spec: libxml2@2.9.7%gcc
+      prefix: /usr
+  lz4:
+    externals:
+    - spec: lz4@1.8.0
+      prefix: /usr
+  m4:
+    externals:
+    - spec: m4@1.4.18%gcc
+      prefix: /usr
+  mpich:
+    buildable: false
+    externals:
+    - spec: mpich@3.2%gcc
+      modules:
+      - cray-mpich/7.7.15
+    - spec: mpich@3.2%intel
+      modules:
+      - cray-mpich/7.7.15
+    - spec: mpich@3.2%cce
+      modules:
+      - cray-mpich/7.7.15
+    - spec: mpich@3.2%pgi
+      modules:
+      - cray-mpich/7.7.15
+  netcdf-c:
+    buildable: false
+    externals:
+    - spec: netcdf-c@4.7.4.0%gcc+parallel-netcdf+mpi
+      modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+    - spec: netcdf-c@4.7.4.0%intel+parallel-netcdf+mpi
+      modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+    - spec: netcdf-c@4.7.4.0%cce+parallel-netcdf+mpi
+      modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+    - spec: netcdf-c@4.7.4.0%pgi+parallel-netcdf+mpi
+      modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+    - spec: netcdf-c@4.7.4.0%gcc~parallel-netcdf~mpi
+      modules:
+      - cray-netcdf/4.7.4.0
+    - spec: netcdf-c@4.7.4.0%intel~parallel-netcdf~mpi
+      modules:
+      - cray-netcdf/4.7.4.0
+    - spec: netcdf-c@4.7.4.0%cce~parallel-netcdf~mpi
+      modules:
+      - cray-netcdf/4.7.4.0
+    - spec: netcdf-c@4.7.4.0%pgi~parallel-netcdf~mpi
+      modules:
+      - cray-netcdf/4.7.4.0
+  netcdf-fortran:
+    buildable: false
+    externals:
+    - spec: netcdf-fortran@4.7.4.0%gcc+mpi
+      modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+    - spec: netcdf-fortran@4.7.4.0%intel+mpi
+      modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+    - spec: netcdf-fortran@4.7.4.0%cce+mpi
+      modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+    - spec: netcdf-fortran@4.7.4.0%pgi+mpi
+      modules:
+      - cray-netcdf-hdf5parallel/4.7.4.0
+  netcdf-cxx4:
+    buildable: false
+    externals:
+    - spec: netcdf-cxx4@4.7.4.0%gcc
+      prefix: /opt/cray/pe/netcdf/4.7.4.0/gnu/8.2/
+    - spec: netcdf-cxx4@4.7.4.0%gcc
+      modules:
+      - cray-netcdf/4.7.4.0
+  netlib-scalapack:
+    variants: build_type=Release
+  netlib-lapack:
+    variants: build_type=Release +external-blas+lapacke
+  openblas:
+    variants: +pic +shared threads=openmp ~virtual_machine
+  openssl:
+    externals:
+    - spec: openssl@1.1.0i
+      prefix: /usr
+  openjdk:
+    externals:
+    - spec: openjdk@11.0.7%gcc
+      prefix: /usr/lib64/jvm/java-11-openjdk
+  papi:
+    buildable: false
+    externals:
+    - spec: papi@6.0.0.2%gcc
+      modules:
+      - papi/6.0.0.2
+    - spec: papi@6.0.0.2%intel
+      modules:
+      - papi/6.0.0.2
+    - spec: papi@6.0.0.2%cce
+      modules:
+      - papi/6.0.0.2
+    - spec: papi@6.0.0.2%pgi
+      modules:
+      - papi/6.0.0.2
+  perl:
+    externals:
+    - spec: perl@5.26.1
+      prefix: /usr
+  pkg-config:
+    externals:
+    - spec: pkg-config@0.29.2
+      prefix: /usr
+  petsc:
+    buildable: false
+    externals:
+    - spec: petsc@3.13.3.0%gcc~complex~int64
+      modules:
+      - cray-petsc/3.13.3.0
+    - spec: petsc@3.13.3.0%intel~complex~int64
+      modules:
+      - cray-petsc/3.13.3.0
+    - spec: petsc@3.13.3.0%cce~complex~int64
+      modules:
+      - cray-petsc/3.13.3.0
+    - spec: petsc@3.13.3.0%pgi~complex~int64
+      modules:
+      - cray-petsc/3.13.3.0
+    - spec: petsc@3.13.3.0%gcc+complex~int64
+      modules:
+      - cray-petsc-complex/3.13.3.0
+    - spec: petsc@3.13.3.0%intel+complex~int64
+      modules:
+      - cray-petsc-complex/3.13.3.0
+    - spec: petsc@3.13.3.0%cce+complex~int64
+      modules:
+      - cray-petsc-complex/3.13.3.0
+    - spec: petsc@3.13.3.0%pgi+complex~int64
+      modules:
+      - cray-petsc-complex/3.13.3.0
+    - spec: petsc@3.13.3.0%gcc~complex+int64
+      modules:
+      - cray-petsc-64/3.13.3.0
+    - spec: petsc@3.13.3.0%intel~complex+int64
+      modules:
+      - cray-petsc-64/3.13.3.0
+    - spec: petsc@3.13.3.0%cce~complex+int64
+      modules:
+      - cray-petsc-64/3.13.3.0
+    - spec: petsc@3.13.3.0%pgi~complex+int64
+      modules:
+      - cray-petsc-64/3.13.3.0
+    - spec: petsc@3.13.3.0%gcc+complex+int64
+      modules:
+      - cray-petsc-complex-64/3.13.3.0
+    - spec: petsc@3.13.3.0%intel+complex+int64
+      modules:
+      - cray-petsc-complex-64/3.13.3.0
+    - spec: petsc@3.13.3.0%cce+complex+int64
+      modules:
+      - cray-petsc-complex-64/3.13.3.0
+    - spec: petsc@3.13.3.0%pgi+complex+int64
+      modules:
+      - cray-petsc-complex-64/3.13.3.0
+  quantum-espresso:
+    variants: ~elpa +mpi +openmp
+  readline:
+    externals:
+    - spec: readline@7.0
+      prefix: /usr
+  slurm:
+    externals:
+    - spec: slurm@20.02.2-1%gcc
+      modules:
+      - slurm/20.02.2-1
+  tar:
+    externals:
+    - spec: tar@1.30.0
+      prefix: /bin
+  trilinos:
+    buildable: false
+    externals:
+    - spec: trilinos@12.18.1.1%gcc
+      modules:
+      - cray-trilinos/12.18.1.1
+    - spec: trilinos@12.18.1.1%intel
+      modules:
+      - cray-trilinos/12.18.1.1
+    - spec: trilinos@12.18.1.1%cce
+      modules:
+      - cray-trilinos/12.18.1.1
+    - spec: trilinos@12.18.1.1%pgi
+      modules:
+      - cray-trilinos/12.18.1.1
+  xz:
+    externals:
+    - spec: xz@5.2.3
+      prefix: /usr
+  zlib:
+    externals:
+    - spec: zlib@1.2.11
+      prefix: /usr

--- a/sysconfigs/daint/packages.yaml
+++ b/sysconfigs/daint/packages.yaml
@@ -273,16 +273,16 @@ packages:
   netcdf-fortran:
     buildable: false
     externals:
-    - spec: netcdf-fortran@4.7.4.0%gcc+mpi
+    - spec: netcdf-fortran@4.7.4.0%gcc
       modules:
       - cray-netcdf-hdf5parallel/4.7.4.0
-    - spec: netcdf-fortran@4.7.4.0%intel+mpi
+    - spec: netcdf-fortran@4.7.4.0%intel
       modules:
       - cray-netcdf-hdf5parallel/4.7.4.0
-    - spec: netcdf-fortran@4.7.4.0%cce+mpi
+    - spec: netcdf-fortran@4.7.4.0%cce
       modules:
       - cray-netcdf-hdf5parallel/4.7.4.0
-    - spec: netcdf-fortran@4.7.4.0%pgi+mpi
+    - spec: netcdf-fortran@4.7.4.0%pgi
       modules:
       - cray-netcdf-hdf5parallel/4.7.4.0
   netcdf-cxx4:

--- a/sysconfigs/tsa/config.yaml
+++ b/sysconfigs/tsa/config.yaml
@@ -1,12 +1,14 @@
 config:
-  install_tree:
-  template_dirs:
-    - $spack/templates
-  module_roots:
-    tcl:
-  build_stage:
-  extensions:
-  install_path_scheme: '{name}/{version}/{compiler.name}/{hash}'
-  source_cache: ~/.spack/source_cache
   build_jobs: 6
+  build_stage:
   db_lock_timeout: 10
+  extensions:
+  install_tree:
+    projections:
+      all: '{name}/{version}/{compiler.name}/{hash}'
+    root: 
+  module_roots:
+    tcl: 
+  source_cache: ~/.spack/source_cache    
+  template_dirs:
+  - $spack/templates

--- a/sysconfigs/tsa/packages.yaml
+++ b/sysconfigs/tsa/packages.yaml
@@ -5,92 +5,138 @@ packages:
       mpicuda: [openmpi+cuda, mpich]
       mpi: [openmpi~cuda]
   cmake:
-    modules:
-      cmake@3.14.5%gcc: cmake/3.14.5
-      cmake@3.14.5%pgi: cmake/3.14.5
     buildable: true
     version: [3.14.5]
     target: []
     providers: {}
     compiler: []
-    paths: {}
+    externals:
+    - spec: cmake@3.14.5%gcc
+      modules:
+      - cmake/3.14.5
+    - spec: cmake@3.14.5%pgi
+      modules:
+      - cmake/3.14.5
   cuda:
-    modules:
-      cuda@10.1.243%gcc: cuda/10.1.243
     buildable: true
     version: []
     target: []
     providers: {}
+    externals:
+    - spec: cuda@10.1.243%gcc
+      modules:
+      - cuda/10.1.243
   openmpi:
-    modules:
-      openmpi@4.0.2%pgi@20.4 +cuda: /apps/arolla/UES/jenkins/RH7.7/MCH-PE20.08-dev0/pgi/20.4/easybuild/modules/all/openmpi/4.0.2-pgi-20.4-gcc-8.3.0-cuda-10.1
-      openmpi@4.0.2%pgi@20.4 ~cuda: /apps/arolla/UES/jenkins/RH7.7/MCH-PE20.08-dev0/pgi/20.4-nocuda/easybuild/modules/all/openmpi/4.0.2-pgi-20.4-gcc-8.3.0-nocuda
-      openmpi@4.0.2%pgi@19.9 +cuda: /apps/arolla/UES/jenkins/RH7.7/MCH-PE20.06/pgi/19.9/easybuild/modules/all/openmpi/4.0.2-pgi-19.9-gcc-8.3.0-cuda-10.1-rh7.7
-      openmpi@4.0.2%pgi@19.9 ~cuda: /apps/arolla/UES/jenkins/RH7.7/MCH-PE20.06/pgi/19.9-nocuda/easybuild/modules/all/openmpi/4.0.2-pgi-19.9-gcc-8.3.0-nocuda
-      openmpi@4.0.2%gcc@8.3.0 +cuda: /apps/arolla/UES/jenkins/RH7.7/MCH-PE20.06/gnu/19.2/easybuild/modules/all/openmpi/4.0.2-gcccuda-2019b-cuda-10.1
-      openmpi@4.0.2%gcc@8.3.0 ~cuda: /apps/arolla/UES/jenkins/RH7.7/MCH-PE20.06/gnu/19.2-nocuda/easybuild/modules/all/openmpi/4.0.2-gcc-8.3.0
     variants: +cuda
+    externals:
+    - spec: openmpi@4.0.2%pgi@20.4 +cuda
+      modules:
+      - /apps/arolla/UES/jenkins/RH7.7/MCH-PE20.08-dev0/pgi/20.4/easybuild/modules/all/openmpi/4.0.2-pgi-20.4-gcc-8.3.0-cuda-10.1
+    - spec: openmpi@4.0.2%pgi@20.4 ~cuda
+      modules:
+      - /apps/arolla/UES/jenkins/RH7.7/MCH-PE20.08-dev0/pgi/20.4-nocuda/easybuild/modules/all/openmpi/4.0.2-pgi-20.4-gcc-8.3.0-nocuda
+    - spec: openmpi@4.0.2%pgi@19.9 +cuda
+      modules:
+      - /apps/arolla/UES/jenkins/RH7.7/MCH-PE20.06/pgi/19.9/easybuild/modules/all/openmpi/4.0.2-pgi-19.9-gcc-8.3.0-cuda-10.1-rh7.7
+    - spec: openmpi@4.0.2%pgi@19.9 ~cuda
+      modules:
+      - /apps/arolla/UES/jenkins/RH7.7/MCH-PE20.06/pgi/19.9-nocuda/easybuild/modules/all/openmpi/4.0.2-pgi-19.9-gcc-8.3.0-nocuda
+    - spec: openmpi@4.0.2%gcc@8.3.0 +cuda
+      modules:
+      - /apps/arolla/UES/jenkins/RH7.7/MCH-PE20.06/gnu/19.2/easybuild/modules/all/openmpi/4.0.2-gcccuda-2019b-cuda-10.1
+    - spec: openmpi@4.0.2%gcc@8.3.0 ~cuda
+      modules:
+      - /apps/arolla/UES/jenkins/RH7.7/MCH-PE20.06/gnu/19.2-nocuda/easybuild/modules/all/openmpi/4.0.2-gcc-8.3.0
   netcdf-fortran:
-    modules:
-      netcdf-fortran@4.4.5%pgi@20.4 +mpi: /apps/arolla/UES/jenkins/RH7.7/MCH-PE20.08-dev0/pgi/20.4/easybuild/modules/all/netcdf-fortran/4.4.5-pgi-20.4-gcc-8.3.0
-      netcdf-fortran@4.4.5%pgi@19.9 +mpi: /apps/arolla/UES/jenkins/RH7.7/pgi/19.9/easybuild/modules/all/netcdf-fortran/4.4.5-pgi-19.9-gcc-8.3.0
-      netcdf-fortran@4.4.5%gcc@8.3.0 +mpi: /apps/arolla/UES/jenkins/RH7.7/gnu/19.2/easybuild/modules/all/netcdf-fortran/4.4.5-fosscuda-2019b   
+    externals:
+    - spec: netcdf-fortran@4.4.5%pgi@20.4
+      modules:
+      - /apps/arolla/UES/jenkins/RH7.7/MCH-PE20.08-dev0/pgi/20.4/easybuild/modules/all/netcdf-fortran/4.4.5-pgi-20.4-gcc-8.3.0
+    - spec: netcdf-fortran@4.4.5%pgi@19.9
+      modules:
+      - /apps/arolla/UES/jenkins/RH7.7/pgi/19.9/easybuild/modules/all/netcdf-fortran/4.4.5-pgi-19.9-gcc-8.3.0
+    - spec: netcdf-fortran@4.4.5%gcc@8.3.0
+      modules:
+      - /apps/arolla/UES/jenkins/RH7.7/gnu/19.2/easybuild/modules/all/netcdf-fortran/4.4.5-fosscuda-2019b
   netcdf-c:
-    modules:
-      netcdf-c@4.7.0%pgi@20.4 +mpi: /apps/arolla/UES/jenkins/RH7.7/MCH-PE20.08-dev0/pgi/20.4/easybuild/modules/all/netcdf/4.7.0-pgi-20.4-gcc-8.3.0
-      netcdf-c@4.7.0%pgi@19.9 +mpi: /apps/arolla/UES/jenkins/RH7.7/pgi/19.9/easybuild/modules/all/netcdf/4.7.0-pgi-19.9-gcc-8.3.0
-      netcdf-c@4.7.0%gcc@8.3.0 +mpi: /apps/arolla/UES/jenkins/RH7.7/gnu/19.2/easybuild/modules/all/netcdf/4.7.0-fosscuda-2019b
+    externals:
+    - spec: netcdf-c@4.7.0%pgi@20.4 +mpi
+      modules:
+      - /apps/arolla/UES/jenkins/RH7.7/MCH-PE20.08-dev0/pgi/20.4/easybuild/modules/all/netcdf/4.7.0-pgi-20.4-gcc-8.3.0
+    - spec: netcdf-c@4.7.0%pgi@19.9 +mpi
+      modules:
+      - /apps/arolla/UES/jenkins/RH7.7/pgi/19.9/easybuild/modules/all/netcdf/4.7.0-pgi-19.9-gcc-8.3.0
+    - spec: netcdf-c@4.7.0%gcc@8.3.0 +mpi
+      modules:
+      - /apps/arolla/UES/jenkins/RH7.7/gnu/19.2/easybuild/modules/all/netcdf/4.7.0-fosscuda-2019b
   netcdf-cxx4:
-    paths:
-      netcdf-cxx4@4.3.0%gcc@8.3.0: /apps/arolla/UES/jenkins/RH7.7/gnu/19.2/easybuild/software/netCDF-C++/4.3.0-fosscuda-2019b/
+    externals:
+    - spec: netcdf-cxx4@4.3.0%gcc@8.3.0
+      prefix: /apps/arolla/UES/jenkins/RH7.7/gnu/19.2/easybuild/software/netCDF-C++/4.3.0-fosscuda-2019b/
   perl:
-    paths: 
-      perl@5.16.3: /usr
+    externals:
+    - spec: perl@5.16.3
+      prefix: /usr
   m4:
-    paths: 
-      m4@1.4.16%gcc: /usr
+    externals:
+    - spec: m4@1.4.16%gcc
+      prefix: /usr
   automake:
-    paths:
-      automake@1.13.4%gcc: /usr
+    externals:
+    - spec: automake@1.13.4%gcc
+      prefix: /usr
   autoconf:
-    paths:
-      autoconf@2.69%gcc: /usr
+    externals:
+    - spec: autoconf@2.69%gcc
+      prefix: /usr
   bison:
-    paths:
-      bison@3.0.4%gcc: /usr
+    externals:
+    - spec: bison@3.0.4%gcc
+      prefix: /usr
   gettext:
-    paths:
-      gettext@0.19.8.1%gcc: /usr
+    externals:
+    - spec: gettext@0.19.8.1%gcc
+      prefix: /usr
   flex:
-    paths:
-      flex@2.5.37%gcc: /usr
+    externals:
+    - spec: flex@2.5.37%gcc
+      prefix: /usr
   ncurses:
-    paths:
-      ncurses@6.1: /usr
+    externals:
+    - spec: ncurses@6.1
+      prefix: /usr
   libxml2:
-    paths:
-      libxml2@2.9.9%gcc: /usr
+    externals:
+    - spec: libxml2@2.9.9%gcc
+      prefix: /usr
   libtool:
-    paths:
-      libtool@2.4.2%gcc: /usr
+    externals:
+    - spec: libtool@2.4.2%gcc
+      prefix: /usr
   openjdk:
-    paths:
-      openjdk@1.8.0%gcc: /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.242.b08-0.el7_7.x86_64/
+    externals:
+    - spec: openjdk@1.8.0%gcc
+      prefix: /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.242.b08-0.el7_7.x86_64/
   jasper:
-    paths:
-      jasper@1.900.1%gcc +shared: /usr
+    externals:
+    - spec: jasper@1.900.1%gcc +shared
+      prefix: /usr
   bzip2:
-    paths:
-      bzip2@1.0.6: /usr
+    externals:
+    - spec: bzip2@1.0.6
+      prefix: /usr
   slurm:
-    modules:
-      slurm@19.05.05%gcc: slurm/19.05.05
+    externals:
+    - spec: slurm@19.05.05%gcc
+      modules:
+      - slurm/19.05.05
   int2lm:
     variants: slave=tsa
   libgrib1:
     variants: slave=tsa
   cosmo-dycore:
-    variants: +cuda cuda_arch=70 data_path=/scratch/jenkins/data/cosmo/ slave=tsa slurm_args= "'-p debug -n {0} --gres=gpu:{0}'"
+    variants: +cuda cuda_arch=70 data_path=/scratch/jenkins/data/cosmo/ slave=tsa
+      slurm_args= "'-p debug -n {0} --gres=gpu:{0}'"
     compiler: [gcc]
   gridtools:
     variants: +cuda cuda_arch=70
@@ -98,4 +144,3 @@ packages:
   cosmo:
     variants: cuda_arch=70 cosmo_target=gpu slave=tsa
     version: [master]
-


### PR DESCRIPTION
The changes are structural changes because of the new version. The config content does not change.
Main structural changes: 
config.py:  'install_tree' goes to install_tree: root:
packages.py: paths is replaced by externals:  - spec: <spec> -prefix: <path>
Packages changes:
netcdf-fortran does not provide the +mpi variant anymore