### PR TITLE
Fix icondusk-e2e's direct dependency on python

### DIFF
--- a/packages/icondusk-e2e/package.py
+++ b/packages/icondusk-e2e/package.py
@@ -26,7 +26,7 @@ class IconduskE2e(CMakePackage):
     depends_on('atlas_utilities', type=('build', 'run'))
     depends_on('dawn4py',  type=('build'))
     depends_on('dusk',  type=('build'))
-    depends_on('python@3.8.0')
+    depends_on('python@3.8.0:3.8.999')
     depends_on('atlas@0.22.0')
     depends_on('cuda', type=('build', 'run'))
 


### PR DESCRIPTION
It became uncompatible with `dusk` which depends on the `3.8.x` version range of python. Fixing by depending on the same version range.