### PR TITLE
Add dawn4py's dependencies to its package.py

### DIFF
--- a/packages/dawn4py/package.py
+++ b/packages/dawn4py/package.py
@@ -24,7 +24,7 @@ class Dawn4py(PythonPackage):
     depends_on('cmake', type='build')
     depends_on('py-setuptools', type='build')
     depends_on('py-protobuf', type=('build','run'))
-    depends_on('py-attr', type=('build','run'))
+    depends_on('py-attrs', type=('build','run'))
     depends_on('py-pytest', type=('build','run'))
     depends_on('py-black', type=('build','run'))
 

--- a/packages/dawn4py/package.py
+++ b/packages/dawn4py/package.py
@@ -24,6 +24,7 @@ class Dawn4py(PythonPackage):
     depends_on('cmake', type='build')
     depends_on('py-setuptools', type='build')
     depends_on('py-protobuf', type=('build','run'))
+    depends_on('py-attr', type=('build','run'))
     depends_on('py-pytest', type=('build','run'))
     depends_on('py-black', type=('build','run'))
 

--- a/packages/dawn4py/package.py
+++ b/packages/dawn4py/package.py
@@ -24,6 +24,8 @@ class Dawn4py(PythonPackage):
     depends_on('cmake', type='build')
     depends_on('py-setuptools', type='build')
     depends_on('py-protobuf', type=('build','run'))
+    depends_on('py-pytest', type=('build','run'))
+    depends_on('py-black', type=('build','run'))
 
     # will test that dawn4py is importable after the install
     import_modules = ['dawn4py']


### PR DESCRIPTION
`dawn4py` depends on `black` and `pytest` (listed as REQUIRED in its `setup.py`). Spack is not very consistent in how it resolves the dependencies defined in the `setup.py` of the package.
In this case, running `dusk` from command line, triggered `pkg_resources.DistributionNotFound` errors for both dawn4py's dependencies.
Solvable by replicating the dependency connection here in the `package.py` of dawn4py.