### PR TITLE
FIX: switch to /lib64 for eccode version >= 2.19.0

### DIFF
--- a/packages/int2lm-org/package.py
+++ b/packages/int2lm-org/package.py
@@ -50,10 +50,16 @@ class Int2lmOrg(MakefilePackage):
         if '~eccodes' in self.spec:
             grib_prefix = self.spec['cosmo-grib-api'].prefix
             grib_lib_names = '-lgrib_api_f90 -lgrib_api'
+            lib_dir='/lib'
         else:
             grib_prefix = self.spec['eccodes'].prefix
             grib_lib_names = '-leccodes_f90 -leccodes'
-        env.set('GRIBAPIL', '-L' + grib_prefix + '/lib ' + grib_lib_names + ' -L' + self.spec['jasper'].prefix + '/lib64 -ljasper')
+            # Default installation lib path changed to from lib to lib64 after 2.19.0
+            if self.spec['eccodes'].version >= Version('2.19.0'):
+                lib_dir='/lib64'
+            else:
+                lib_dir='/lib'
+        env.set('GRIBAPIL', '-L' + grib_prefix + lib_dir + grib_lib_names + ' -L' + self.spec['jasper'].prefix + '/lib64 -ljasper')
         env.set('GRIBAPII', '-I' + grib_prefix + '/include')
 
         # Netcdf library

--- a/packages/int2lm-org/package.py
+++ b/packages/int2lm-org/package.py
@@ -49,11 +49,11 @@ class Int2lmOrg(MakefilePackage):
         # Grib-api. Eccodes libraries
         if '~eccodes' in self.spec:
             grib_prefix = self.spec['cosmo-grib-api'].prefix
-            grib_lib_names = '-lgrib_api_f90 -lgrib_api'
+            grib_lib_names = ' -lgrib_api_f90 -lgrib_api'
             lib_dir='/lib'
         else:
             grib_prefix = self.spec['eccodes'].prefix
-            grib_lib_names = '-leccodes_f90 -leccodes'
+            grib_lib_names = ' -leccodes_f90 -leccodes'
             # Default installation lib path changed to from lib to lib64 after 2.19.0
             if self.spec['eccodes'].version >= Version('2.19.0'):
                 lib_dir='/lib64'


### PR DESCRIPTION
Similar to #159 but for int2lm-org