### PR TITLE
Set dependecy type for all int2lm dependecy

### DIFF
--- a/packages/int2lm-org/package.py
+++ b/packages/int2lm-org/package.py
@@ -29,10 +29,10 @@ class Int2lmOrg(MakefilePackage):
 
     depends_on('cosmo-grib-api-definitions', type=('build','run'), when='~eccodes')
     depends_on('cosmo-eccodes-definitions ~aec', type=('build','run'), when='+eccodes')
-    depends_on('libgrib1@master')
+    depends_on('libgrib1@master', type='build')
     depends_on('mpi', type=('build', 'link', 'run'), when='+parallel')
-    depends_on('netcdf-c')
-    depends_on('netcdf-fortran +mpi')
+    depends_on('netcdf-c',type=('build', 'link'))
+    depends_on('netcdf-fortran +mpi',type=('build', 'link'))
 
     variant('debug', default=False, description='Build debug INT2LM')
     variant('eccodes', default=True, description='Build with eccodes instead of grib-api')

--- a/packages/int2lm/package.py
+++ b/packages/int2lm/package.py
@@ -46,10 +46,10 @@ class Int2lm(MakefilePackage):
 
     depends_on('cosmo-grib-api-definitions', type=('build','run'), when='~eccodes')
     depends_on('cosmo-eccodes-definitions ~aec', type=('build','run'), when='+eccodes')
-    depends_on('libgrib1@master')
+    depends_on('libgrib1@master', type='build')
     depends_on('mpi', type=('build', 'link', 'run'), when='+parallel')
-    depends_on('netcdf-c')
-    depends_on('netcdf-fortran +mpi')
+    depends_on('netcdf-c',type=('build', 'link'))
+    depends_on('netcdf-fortran +mpi', type=('build', 'link'))
 
     variant('debug', default=False, description='Build debug INT2LM')
     variant('eccodes', default=True, description='Build with eccodes instead of grib-api')


### PR DESCRIPTION
Avoid having libgrib1 in run-env