### PR TITLE
Fix shadow release

### DIFF
--- a/packages/cosmo/package.py
+++ b/packages/cosmo/package.py
@@ -12,35 +12,40 @@ def get_releases(repo):
         git_tags = [re.match('refs/tags/(.*)', x.decode('utf-8')).group(1) for x in git_obj.stdout.split() if re.match('refs/tags/(.*)', x.decode('utf-8'))]
         return git_tags
 
-def dycore_deps(repo):
+def set_versions(repo, reg_filter=None):
+    def filterfn(repo_tag):
+        return re.match(reg_filter, repo_tag) != None
+
     tags = get_releases(repo)
+    if reg_filter:
+        tags = list(filter(filterfn, tags))
+
     for tag in tags:
         version(tag, git=repo, tag=tag, get_full_repo=True)
 
-    tags.append('master')
-    tags.append('dev-build')
-    tags.append('mch')
-    tags.append('c2sm')
+def set_dycore_dep():
+    types = ['float','double']
+    prod = [True,False]
+    cuda = [True, False]
+    testing = [True, False]
+    gt1 = [True, False]
+    comb=list(itertools.product(*[types, prod, cuda, testing, gt1]))
+    for it in comb:
+        real_type=it[0]
+        prod_opt = '+production' if it[1] else '~production'
+        cuda_opt = '+cuda' if it[2] else '~cuda cuda_arch=none'
+        cuda_dep = 'cosmo_target=gpu' if it[2] else ' cosmo_target=cpu'
+        test_opt = '+build_tests' if it[3] else '~build_tests'
+        test_dep = '+dycoretest' if it[3] else '~dycoretest'
+        gt1_dep = '+gt1' if it[4] else '~gt1'
 
-    for tag in tags:    
-        types = ['float','double']
-        prod = [True,False]
-        cuda = [True, False]
-        testing = [True, False]
-        gt1 = [True, False]
-        comb=list(itertools.product(*[types, prod, cuda, testing, gt1]))
-        for it in comb:
-            real_type=it[0]
-            prod_opt = '+production' if it[1] else '~production'
-            cuda_opt = '+cuda' if it[2] else '~cuda cuda_arch=none'
-            cuda_dep = 'cosmo_target=gpu' if it[2] else ' cosmo_target=cpu'
-            test_opt = '+build_tests' if it[3] else '~build_tests'
-            test_dep = '+dycoretest' if it[3] else '~dycoretest'
-            gt1_dep = '+gt1' if it[4] else '~gt1'
+        orig='cosmo-dycore'+' real_type='+real_type+' '+ prod_opt + ' ' + cuda_opt+' ' +test_opt + ' ' + gt1_dep
+        #orig='cosmo-dycore'+' real_type='+real_type+' '+ prod_opt + ' ' + cuda_opt+' ' +test_opt + ' ' + gt1_dep
+        dep='real_type='+real_type+' '+ prod_opt + ' '+ cuda_dep + ' +cppdycore'+' '+test_dep + ' ' + gt1_dep
+        depends_on(orig, when=dep, type='build')
 
-            orig='cosmo-dycore@'+tag+'%gcc@8.1.0:8.4.0 real_type='+real_type+' '+ prod_opt + ' ' + cuda_opt+' ' +test_opt + ' ' + gt1_dep
-            dep='@'+tag+' real_type='+real_type+' '+ prod_opt + ' '+ cuda_dep + ' +cppdycore'+' '+test_dep + ' ' + gt1_dep
-            depends_on(orig, when=dep, type='build')
+
+
 
 class Cosmo(MakefilePackage):
     """COSMO: Numerical Weather Prediction Model. Needs access to private GitHub."""
@@ -60,8 +65,10 @@ class Cosmo(MakefilePackage):
     patch('patches/5.07.mch1.0.p4/patch.Makefile', when='@5.07.mch1.0.p4')
     patch('patches/5.07.mch1.0.p4/patch.Makefile', when='@5.07.mch1.0.p5')
 
-    dycore_deps(apngit)
-#    dycore_deps(c2smgit)
+    set_versions(apngit, reg_filter='.*mch.*')
+    set_versions(c2smgit)
+
+    set_dycore_dep()
 
     depends_on('netcdf-fortran +mpi', type=('build', 'link'))
     depends_on('netcdf-c +mpi', type=('build', 'link'))

--- a/packages/cosmo/package.py
+++ b/packages/cosmo/package.py
@@ -39,7 +39,7 @@ def set_dycore_dep():
         test_dep = '+dycoretest' if it[3] else '~dycoretest'
         gt1_dep = '+gt1' if it[4] else '~gt1'
 
-        orig='cosmo-dycore'+' real_type='+real_type+' '+ prod_opt + ' ' + cuda_opt+' ' +test_opt + ' ' + gt1_dep
+        orig='cosmo-dycore%gcc@8.1.0:8.4.0'+' real_type='+real_type+' '+ prod_opt + ' ' + cuda_opt+' ' +test_opt + ' ' + gt1_dep
         #orig='cosmo-dycore'+' real_type='+real_type+' '+ prod_opt + ' ' + cuda_opt+' ' +test_opt + ' ' + gt1_dep
         dep='real_type='+real_type+' '+ prod_opt + ' '+ cuda_dep + ' +cppdycore'+' '+test_dep + ' ' + gt1_dep
         depends_on(orig, when=dep, type='build')

--- a/packages/cosmo/package.py
+++ b/packages/cosmo/package.py
@@ -61,7 +61,7 @@ class Cosmo(MakefilePackage):
     patch('patches/5.07.mch1.0.p4/patch.Makefile', when='@5.07.mch1.0.p5')
 
     dycore_deps(apngit)
-    dycore_deps(c2smgit)
+#    dycore_deps(c2smgit)
 
     depends_on('netcdf-fortran +mpi', type=('build', 'link'))
     depends_on('netcdf-c +mpi', type=('build', 'link'))


### PR DESCRIPTION
Description
-------------------

This PR fixes a bug introduced with #161. As a result, after #161 master can not build releases any longer. 
The problem was triggered by this line: 
https://github.com/MeteoSwiss-APN/spack-mch/blob/4ae467939db6f9c15e75b72690728458dfad0527/packages/cosmo/package.py#L43
That is setting a dependency of the like
```
depends_on('cosmo-dycore@aversion', when='@aversion', type='build')
```

That goal was to fix within  spack what version of dycore can and should be build depending on the version of cosmo. This is a tight requirement, since in principle a version of the dycore can be compatible with multiple versions of cosmo, as far as there are no changes in the dycore and in particular in the API. 
However, without it, any version of cosmo will be built against the latest of the dycore, which will lead users to error prone compilations unless always specify in the spec the version of the dycore required: 
```
spack install cosmo@v2.3.4 ^cosmo-dycore@v2.3.4 ...
```

However the solution employing the depends_on is problematic... 
If there are releases that as a string is a subset of another, spack fails to resolve the spec. 
This happened when adding the new releases of c2sm, which included all the releases of cosmo-org. 
For example: 5.08.mch1.0.p1 and 5.08 will clash, and even if there is no reason why it should not work, spack fails to concretize the spec. 

Therefore the proposal if this PR is to remove that mechanism. 
We set of the releases of mch apn and c2sm (avoiding clashes by filtering the apn ones with the substring 'mch') but we dont specify the version of the dycore cosmo will depend on. 

Notice, this is a change of paradigm proposed here:
* Spack set conflicts and dependencies, however it is not a release manager. It does not specify for each specific release the releases of the dependencies that should be used. 
Like that, we will need a small external spec builder, which will build the spec of spack for each release of cosmo for the user, in order to avoid the error prone situation when the user needs to set by hand all versions of dependencies. 

I am working on a solution in that direction, but to be discussed first, before we continue with this PR

@kosterried @jonasjucker @lxavier 