### PR TITLE
Fix for MCH release

### DIFF
--- a/packages/cosmo/package.py
+++ b/packages/cosmo/package.py
@@ -61,7 +61,8 @@ class Cosmo(MakefilePackage):
     patch('patches/5.07.mch1.0.p4/patch.Makefile', when='@5.07.mch1.0.p5')
 
     dycore_deps(apngit)
-    dycore_deps(c2smgit)
+    # Uncomment to build c2sm release 
+    # dycore_deps(c2smgit)
 
     depends_on('netcdf-fortran +mpi', type=('build', 'link'))
     depends_on('netcdf-c +mpi', type=('build', 'link'))


### PR DESCRIPTION
This allow mch to build releases, but C2SM will not work anymore - this is a temporary solution