### PR TITLE
install build env

### DIFF
--- a/packages/cosmo/package.py
+++ b/packages/cosmo/package.py
@@ -262,6 +262,9 @@ class Cosmo(MakefilePackage):
                 OptionsFile.filter('PFLAGS   = -Mpreprocess.*', 'PFLAGS   = -Mpreprocess -DNO_ACC_FINALIZE')
 
     def install(self, spec, prefix):
+        package = spack.repo.get(spec)
+        install(package.env_path, prefix)
+
         with working_dir(self.build_directory):
             mkdir(prefix.bin)
             if '+serialize' in spec:


### PR DESCRIPTION
Install the spack build env, in order to avoid having to find it in the stage path when deploying the install 