### PR TITLE
Improved behaviour of config for spack installation

### DIFF
--- a/config.py
+++ b/config.py
@@ -72,7 +72,7 @@ def main():
 
     # copy config.yaml file in site scope of spack instance
     configfile = args.idir + '/spack/etc/spack' + '/config.yaml'
- 
+
     shutil.copy('sysconfigs/' + args.machine.replace('admin-', '') +
                 '/config.yaml', configfile)
 
@@ -100,12 +100,13 @@ def main():
     config_data['config']['module_roots']['tcl'] = args.pckgidir + \
         '/modules/' + args.machine
     config_data['config']['extensions'] = [dir_path + '/tools/spack-scripting']
-    yaml.safe_dump(config_data, open(configfile, 'w'), default_flow_style=False)
+    yaml.safe_dump(config_data, open(configfile, 'w'),
+                   default_flow_style=False)
 
     # copy modified upstreams.yaml if not admin
     if args.upstreams == 'ON':
         upstreamfile = args.idir + '/spack/etc/spack' + '/upstreams.yaml'
-        shutil.copy('sysconfigs/upstreams.yaml',upstreamfile)
+        shutil.copy('sysconfigs/upstreams.yaml', upstreamfile)
 
         upstreams_data = yaml.safe_load(
             open(upstreamfile, 'r'))

--- a/config.py
+++ b/config.py
@@ -116,10 +116,13 @@ def main():
             upstreamfile, 'w'), default_flow_style=False)
 
     # copy modules.yaml, packages.yaml and compiles.yaml files in site scope of spack instance
-    os.popen('cp -rf sysconfigs/' + args.machine.replace('admin-',
-                                                         '') + '/* ' + args.idir + '/spack/etc/spack')
+    config_files = ["compilers.yaml", "modules.yaml", "packages.yaml"]
+    for afile in config_files:
+        subprocess.run('cp sysconfigs/' + args.machine.replace('admin-',
+                                                               '') + '/' + afile+' ' + args.idir + '/spack/etc/spack', check=True)
 
-    print('MCH Spack installed.')
+    print('Spack successfully installed. \n source '+args.idir +
+          '/spack/share/spack/setup-env.sh for setting up the instance')
 
 
 if __name__ == "__main__":

--- a/config.py
+++ b/config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 import argparse
 import os
@@ -118,8 +118,9 @@ def main():
     # copy modules.yaml, packages.yaml and compiles.yaml files in site scope of spack instance
     config_files = ["compilers.yaml", "modules.yaml", "packages.yaml"]
     for afile in config_files:
-        subprocess.run('cp sysconfigs/' + args.machine.replace('admin-',
-                                                               '') + '/' + afile+' ' + args.idir + '/spack/etc/spack', check=True)
+        cmd='cp '+dir_path+'/sysconfigs/' + args.machine.replace('admin-',
+                                                               '') + '/' + afile+' ' + args.idir + '/spack/etc/spack/'
+        subprocess.run(cmd.split(), check=True)
 
     print('Spack successfully installed. \n source '+args.idir +
           '/spack/share/spack/setup-env.sh for setting up the instance')

--- a/config.py
+++ b/config.py
@@ -8,20 +8,30 @@ import subprocess
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 
-spack_version='v0.15.4'
-spack_repo='git@github.com:spack/spack.git'
+spack_version = 'v0.15.4'
+spack_repo = 'git@github.com:spack/spack.git'
+
 
 def main():
-    parser=argparse.ArgumentParser(description='Small config script which can be used to install a spack instance with the correct configuration files and mch spack packages.')
-    parser.add_argument('-i', '--idir', type=str, default=dir_path, help='Where the Spack instance is installed or you want it to be installed')
-    parser.add_argument('-m', '--machine', type=str, help='Required: machine name')
-    parser.add_argument('-u', '--upstreams', type=str, default='ON', help='ON or OFF, install upstreams.yaml file')
-    parser.add_argument('-v', '--version', type=str, default=spack_version, help='Spack version, Default: ' + spack_version)
-    parser.add_argument('-r', '--reposdir', type=str, help='repos.yaml install directory')
-    parser.add_argument('-p', '--pckgidir', type=str, help='Define spack package, modules installation directory. Default: tsa; /scratch/$USER/spack, daint; /scratch/snx3000/$USER/spack')
-    parser.add_argument('-s', '--stgidir', type=str, help='Define spack stages directory. Default: tsa; /scratch/$USER/spack, daint; /scratch/snx3000/$USER/spack')
-    parser.add_argument('-c', '--cacheidir', type=str, help='Define spack caches (source and misc)  directories. Default:  ~/.spack/machine/source_cache and ~/.spack/machine/cache')
-    args=parser.parse_args()
+    parser = argparse.ArgumentParser(
+        description='Small config script which can be used to install a spack instance with the correct configuration files and mch spack packages.')
+    parser.add_argument('-i', '--idir', type=str, default=dir_path,
+                        help='Where the Spack instance is installed or you want it to be installed')
+    parser.add_argument('-m', '--machine', type=str,
+                        help='Required: machine name')
+    parser.add_argument('-u', '--upstreams', type=str, default='ON',
+                        help='ON or OFF, install upstreams.yaml file')
+    parser.add_argument('-v', '--version', type=str, default=spack_version,
+                        help='Spack version, Default: ' + spack_version)
+    parser.add_argument('-r', '--reposdir', type=str,
+                        help='repos.yaml install directory')
+    parser.add_argument('-p', '--pckgidir', type=str,
+                        help='Define spack package, modules installation directory. Default: tsa; /scratch/$USER/spack, daint; /scratch/snx3000/$USER/spack')
+    parser.add_argument('-s', '--stgidir', type=str,
+                        help='Define spack stages directory. Default: tsa; /scratch/$USER/spack, daint; /scratch/snx3000/$USER/spack')
+    parser.add_argument('-c', '--cacheidir', type=str,
+                        help='Define spack caches (source and misc)  directories. Default:  ~/.spack/machine/source_cache and ~/.spack/machine/cache')
+    args = parser.parse_args()
 
     if args.upstreams != 'OFF' and args.upstreams != 'ON':
         print('Upstreams must be set to ON or OFF!')
@@ -36,24 +46,31 @@ def main():
             print('Cloning spack instance to: ' + args.idir)
             if args.version is None:
                 args.version = spack_version
-            os.system('git clone {repo} -b {branch} {dest_dir}'.format(repo=spack_repo, branch=args.version, dest_dir=os.path.join(args.idir, 'spack')))
+            os.system('git clone {repo} -b {branch} {dest_dir}'.format(
+                repo=spack_repo, branch=args.version, dest_dir=os.path.join(args.idir, 'spack')))
             print('Installing custom dev-build command')
-            shutil.copy('./tools/spack-scripting/scripting/cmd/dev_build.py', args.idir + '/spack/lib/spack/spack/cmd/')
+            shutil.copy('./tools/spack-scripting/scripting/cmd/dev_build.py',
+                        args.idir + '/spack/lib/spack/spack/cmd/')
     print('Installing mch packages & ' + args.machine + ' config files')
 
     if not args.reposdir:
         args.reposdir = args.idir + '/spack/etc/spack'
 
     # installing repos.yaml
-    if os.path.isdir(args.reposdir) and not os.path.isfile(args.reposdir + '/repos.yaml'):
-        repos_data = yaml.safe_load(open('./sysconfigs/repos.yaml', 'r'))
-        repos_data['repos'] = [dir_path]
-        yaml.safe_dump(repos_data, open('./sysconfigs/repos.yaml', 'w'), default_flow_style=False)
-        print('Installing repos.yaml on ' + args.reposdir)
-        shutil.copy(dir_path + '/sysconfigs/repos.yaml', args.reposdir)
+    if not os.path.isdir(args.reposdir):
+        raise FileNotFoundError(
+            "repository directory requested with -r does not exists: "+args.reposdir)
+
+    print('Installing repos.yaml on ' + args.reposdir)
+    shutil.copy(dir_path + '/sysconfigs/repos.yaml', args.reposdir)
+    reposfile = os.path.join(args.reposdir, '/repos.yaml')
+    repos_data = yaml.safe_load(open(reposfile, 'r'))
+    repos_data['repos'] = [dir_path]
+    yaml.safe_dump(repos_data, open(reposfile, 'w'), default_flow_style=False)
 
     # configure config.yaml
-    config_data = yaml.safe_load(open('sysconfigs/' + args.machine.replace('admin-', '') + '/config.yaml', 'r'))
+    config_data = yaml.safe_load(
+        open('sysconfigs/' + args.machine.replace('admin-', '') + '/config.yaml', 'r'))
 
     if not args.pckgidir:
         if 'admin' in args.machine:
@@ -66,28 +83,41 @@ def main():
 
     if not args.cacheidir:
         args.cacheidir = '~/.spack'
-    config_data['config']['install_tree'] = args.pckgidir + '/spack-install/' + args.machine.replace('admin-', '')
-    config_data['config']['source_cache'] = args.cacheidir + '/' + args.machine.replace('admin-', '') + '/source_cache'
-    config_data['config']['misc_cache'] = args.cacheidir + '/' + args.machine.replace('admin-', '') + '/cache'
-    config_data['config']['build_stage'] = [args.stgidir + '/spack-stages/' + args.machine]
-    config_data['config']['module_roots']['tcl'] = args.pckgidir + '/modules/' + args.machine
+    config_data['config']['install_tree'] = args.pckgidir + \
+        '/spack-install/' + args.machine.replace('admin-', '')
+    config_data['config']['source_cache'] = args.cacheidir + \
+        '/' + args.machine.replace('admin-', '') + '/source_cache'
+    config_data['config']['misc_cache'] = args.cacheidir + \
+        '/' + args.machine.replace('admin-', '') + '/cache'
+    config_data['config']['build_stage'] = [
+        args.stgidir + '/spack-stages/' + args.machine]
+    config_data['config']['module_roots']['tcl'] = args.pckgidir + \
+        '/modules/' + args.machine
     config_data['config']['extensions'] = [dir_path + '/tools/spack-scripting']
-    yaml.safe_dump(config_data, open('./sysconfigs/' + args.machine.replace('admin-', '') + '/config.yaml', 'w'), default_flow_style=False)
+    yaml.safe_dump(config_data, open('./sysconfigs/' + args.machine.replace(
+        'admin-', '') + '/config.yaml', 'w'), default_flow_style=False)
 
     # copy modified config.yaml file in site scope of spack instance
-    shutil.copy('sysconfigs/' + args.machine.replace('admin-', '') + '/config.yaml', args.idir + '/spack/etc/spack')
+    shutil.copy('sysconfigs/' + args.machine.replace('admin-', '') +
+                '/config.yaml', args.idir + '/spack/etc/spack')
 
     # copy modified upstreams.yaml if not admin
-    if args.upstreams=='ON':
-        upstreams_data = yaml.safe_load(open('./sysconfigs/upstreams.yaml', 'r'))
-        upstreams_data['upstreams']['spack-instance-1']['install_tree'] = '/project/g110/spack-install/' + args.machine.replace('admin-', '')
-        yaml.safe_dump(upstreams_data, open('./sysconfigs/upstreams.yaml', 'w'), default_flow_style=False)
-        shutil.copy('sysconfigs/upstreams.yaml', args.idir + '/spack/etc/spack')
+    if args.upstreams == 'ON':
+        upstreams_data = yaml.safe_load(
+            open('./sysconfigs/upstreams.yaml', 'r'))
+        upstreams_data['upstreams']['spack-instance-1']['install_tree'] = '/project/g110/spack-install/' + \
+            args.machine.replace('admin-', '')
+        yaml.safe_dump(upstreams_data, open(
+            './sysconfigs/upstreams.yaml', 'w'), default_flow_style=False)
+        shutil.copy('sysconfigs/upstreams.yaml',
+                    args.idir + '/spack/etc/spack')
 
     # copy modules.yaml, packages.yaml and compiles.yaml files in site scope of spack instance
-    os.popen('cp -rf sysconfigs/' + args.machine.replace('admin-', '') + '/* ' +  args.idir + '/spack/etc/spack')
+    os.popen('cp -rf sysconfigs/' + args.machine.replace('admin-',
+                                                         '') + '/* ' + args.idir + '/spack/etc/spack')
 
     print('MCH Spack installed.')
+
 
 if __name__ == "__main__":
     main()

--- a/config.py
+++ b/config.py
@@ -46,8 +46,9 @@ def main():
             print('Cloning spack instance to: ' + args.idir)
             if args.version is None:
                 args.version = spack_version
-            os.system('git clone {repo} -b {branch} {dest_dir}'.format(
-                repo=spack_repo, branch=args.version, dest_dir=os.path.join(args.idir, 'spack')))
+            cmd = 'git clone {repo} -b {branch} {dest_dir}'.format(
+                repo=spack_repo, branch=args.version, dest_dir=os.path.join(args.idir, 'spack'))
+            subprocess.run(cmd.split(), check=True)
             print('Installing custom dev-build command')
             shutil.copy('./tools/spack-scripting/scripting/cmd/dev_build.py',
                         args.idir + '/spack/lib/spack/spack/cmd/')

--- a/config.py
+++ b/config.py
@@ -118,8 +118,8 @@ def main():
     # copy modules.yaml, packages.yaml and compiles.yaml files in site scope of spack instance
     config_files = ["compilers.yaml", "modules.yaml", "packages.yaml"]
     for afile in config_files:
-        cmd='cp '+dir_path+'/sysconfigs/' + args.machine.replace('admin-',
-                                                               '') + '/' + afile+' ' + args.idir + '/spack/etc/spack/'
+        cmd = 'cp '+dir_path+'/sysconfigs/' + args.machine.replace('admin-',
+                                                                   '') + '/' + afile+' ' + args.idir + '/spack/etc/spack/'
         subprocess.run(cmd.split(), check=True)
 
     print('Spack successfully installed. \n source '+args.idir +


### PR DESCRIPTION
 Technical description: 
==================

it includes several modifications in order to eliminate error prone behaviour. 

* If the specified reposdir (or default) does not exits throw an exception instead of silently ignoring the user choice.
* If args.reposdir + '/repos.yaml' already exists, replace it anyway. It is expected that config.py will create a new installation overwrite previous installations.
* For all the various configurations, do not modify the source of spack-mch, but rather the installed instances
* replace all os.system with subprocess.run(..., check=True) so that a failure will throw an exception
* replace a greedy `cp -rf * ` by explicit requirement of copies
* PEP8 formatting
* python2 -> python3 (required by subprocess.run)
 
Testing:
=======
Tested with 
```
./config.py -m tsa -i $PWD -r $PWD/spack/etc/spack -u ON -p $PWD/spack-install -s $PWD/spack-stg
./config.py -m tsa -i $PWD -r $PWD/spack/etc/spack -u OFF -p $PWD/spack-install -s $PWD/spack-stg
./config.py -m tsa -i $PWD -r $PWD/spack/etc/spack -u OFF
```
and diff spack/etc/spack is the same as the one produced with master