### PR TITLE
Do not install env in case of devbuild

### DIFF
--- a/packages/cosmo/package.py
+++ b/packages/cosmo/package.py
@@ -262,14 +262,7 @@ class Cosmo(MakefilePackage):
                 OptionsFile.filter('PFLAGS   = -Mpreprocess.*', 'PFLAGS   = -Mpreprocess -DNO_ACC_FINALIZE')
 
     def install(self, spec, prefix):
-        package = spack.repo.get(spec)
-        #Package.env_path is incorrect in case of a devbuild, as it looks for the file in stage
-        #Current workaround do not install env file in case of devbuild
-        #todo: devbuild is identified by the version, this is not general and should be improved
-        #better solution would be to correctly localise the env file
-        if spec.format('{version}') != 'dev-build':                                                                                             
-            install(package.env_path, prefix)
-
+        
         with working_dir(self.build_directory):
             mkdir(prefix.bin)
             if '+serialize' in spec:

--- a/packages/cosmo/package.py
+++ b/packages/cosmo/package.py
@@ -263,7 +263,12 @@ class Cosmo(MakefilePackage):
 
     def install(self, spec, prefix):
         package = spack.repo.get(spec)
-        install(package.env_path, prefix)
+        #Package.env_path is incorrect in case of a devbuild, as it looks for the file in stage
+        #Current workaround do not install env file in case of devbuild
+        #todo: devbuild is identified by the version, this is not general and should be improved
+        #better solution would be to correctly localise the env file
+        if spec.format('{version}') != 'dev-build':                                                                                             
+            install(package.env_path, prefix)
 
         with working_dir(self.build_directory):
             mkdir(prefix.bin)


### PR DESCRIPTION
This cause an error as package.env_path is incorrect in case of a devbuild, as it looks for the file in stage
Fix the dev-build command and the cosmo_PR plan in jenkins which is currently broken