### PR TITLE
update daint

### DIFF
--- a/sysconfigs/daint/compilers.yaml
+++ b/sysconfigs/daint/compilers.yaml
@@ -1,5 +1,22 @@
 compilers:
 - compiler:
+    spec: cce@11.0.0
+    environment: {}
+    extra_rpaths: []
+    flags: {}
+    modules:
+    - PrgEnv-cray
+    - cce/11.0.0
+    - cdt/20.11
+    - cce/11.0.0
+    operating_system: cnl7
+    paths:
+      cc: cc
+      cxx: CC
+      f77: ftn
+      fc: ftn
+    target: any
+- compiler:
     spec: cce@10.0.2
     paths:
       cc: cc
@@ -11,6 +28,8 @@ compilers:
     target: any
     modules:
     - PrgEnv-cray
+    - cce/10.0.2
+    - cdt/20.08
     - cce/10.0.2
     environment: {}
     extra_rpaths: []
@@ -27,6 +46,8 @@ compilers:
     modules:
     - PrgEnv-gnu
     - gcc/8.1.0
+    - cdt/20.11
+    - gcc/8.1.0
     environment: {}
     extra_rpaths: []
 - compiler:
@@ -41,6 +62,8 @@ compilers:
     target: any
     modules:
     - PrgEnv-gnu
+    - gcc/8.3.0
+    - cdt/20.11
     - gcc/8.3.0
     environment: {}
     extra_rpaths: []
@@ -57,6 +80,8 @@ compilers:
     modules:
     - PrgEnv-gnu
     - gcc/9.3.0
+    - cdt/20.11
+    - gcc/9.3.0
     environment: {}
     extra_rpaths: []
 - compiler:
@@ -71,6 +96,8 @@ compilers:
     target: any
     modules:
     - PrgEnv-intel
+    - intel/19.0.1.144
+    - cdt/20.11
     - intel/19.0.1.144
     environment: {}
     extra_rpaths: []
@@ -87,6 +114,8 @@ compilers:
     modules:
     - PrgEnv-intel
     - intel/19.1.1.217
+    - cdt/20.11
+    - intel/19.1.1.217
     environment: {}
     extra_rpaths: []
 - compiler:
@@ -102,6 +131,8 @@ compilers:
     modules:
     - PrgEnv-pgi
     - pgi/20.1.0
+    - cdt/20.11
+    - pgi/20.1.0
     environment: {}
     extra_rpaths: []
 - compiler:
@@ -116,6 +147,8 @@ compilers:
     target: any
     modules:
     - PrgEnv-pgi
+    - pgi/20.1.1
+    - cdt/20.11
     - pgi/20.1.1
     environment: {}
     extra_rpaths: []

--- a/sysconfigs/daint/packages.yaml
+++ b/sysconfigs/daint/packages.yaml
@@ -4,7 +4,7 @@ packages:
     all:
         # default compilers defined by the system
         # these reflect the current installed PE
-        compiler: [pgi@20.1.1, pgi@20.1.0, gcc@9.3.0, gcc@8.3.0, gcc@8.1.0, cce@10.0.2, intel@19.1.1.217, intel@19.0.1.144]
+        compiler: [pgi@20.1.1, pgi@20.1.0, gcc@9.3.0, gcc@8.3.0, gcc@8.1.0, cce@10.0.2, cce@11.0.0, intel@19.1.1.217, intel@19.0.1.144]
         providers:
             mpi: [mpich]
             # if the mpich package support +cuda in the future it needs to be put there
@@ -52,10 +52,10 @@ packages:
     cray-libsci:
         buildable: false
         modules:
-            cray-libsci@20.06.1%gcc:   cray-libsci
-            cray-libsci@20.06.1%intel: cray-libsci
-            cray-libsci@20.06.1%cce:   cray-libsci
-            cray-libsci@20.06.1%pgi:   cray-libsci
+            cray-libsci@20.06.1%gcc:   cray-libsci/20.06.1
+            cray-libsci@20.06.1%intel: cray-libsci/20.06.1
+            cray-libsci@20.06.1%cce:   cray-libsci/20.06.1
+            cray-libsci@20.06.1%pgi:   cray-libsci/20.06.1
         paths:
             cray-libsci@20.06.1%cce: /opt/cray/pe/libsci/20.06.1/CRAYCLANG/9.0/x86_64
 


### PR DESCRIPTION
This PR updates the yaml for Daint after discussion with CSCS-support.
The main change is, that one needs to load the compiler modules twice, because Spack expects
it to be loaded right after the PRgEnv-modules, but the cdt module need to be loaded as well.
Additionally CCE 11 is introduced.