### PR TITLE
Change C2SM repository path

### DIFF
--- a/packages/cosmo-dycore/package.py
+++ b/packages/cosmo-dycore/package.py
@@ -44,10 +44,10 @@ class CosmoDycore(CMakePackage):
     version('master', branch='master')
     version('dev-build', branch='master')
     version('mch', git='git@github.com:MeteoSwiss-APN/cosmo.git', branch='mch')
-    version('c2sm', git='git@github.com:C2SM-RCM/cosmo-1.git', branch='master')
+    version('c2sm', git='git@github.com:C2SM-RCM/cosmo.git', branch='master')
 
     dycore_tags("git@github.com:MeteoSwiss-APN/cosmo.git")
-    dycore_tags("git@github.com:C2SM-RCM/cosmo-1.git")
+    dycore_tags("git@github.com:C2SM-RCM/cosmo.git")
 
     variant('build_type', default='Release', description='Build type', values=('Debug', 'Release', 'DebugRelease'))
     variant('build_tests', default=True, description="Compile Dycore unittests & regressiontests")

--- a/packages/cosmo/package.py
+++ b/packages/cosmo/package.py
@@ -49,13 +49,13 @@ class Cosmo(MakefilePackage):
     url      = "https://github.com/MeteoSwiss-APN/cosmo/archive/5.07.mch1.0.p5.tar.gz"
     git      = 'git@github.com:COSMO-ORG/cosmo.git'
     apngit   = 'git@github.com:MeteoSwiss-APN/cosmo.git'
-    c2smgit  = 'git@github.com:C2SM-RCM/cosmo-1.git'
+    c2smgit  = 'git@github.com:C2SM-RCM/cosmo.git'
     maintainers = ['elsagermann']
 
     version('master', branch='master', get_full_repo=True)
     version('dev-build', branch='master', get_full_repo=True)
     version('mch', git='git@github.com:MeteoSwiss-APN/cosmo.git', branch='mch', get_full_repo=True)
-    version('c2sm', git='git@github.com:C2SM-RCM/cosmo-1.git', branch='master', get_full_repo=True)
+    version('c2sm', git='git@github.com:C2SM-RCM/cosmo.git', branch='master', get_full_repo=True)
 
     patch('patches/5.07.mch1.0.p4/patch.Makefile', when='@5.07.mch1.0.p4')
     patch('patches/5.07.mch1.0.p4/patch.Makefile', when='@5.07.mch1.0.p5')


### PR DESCRIPTION
The name of the cosmo repository changed in C2SM-RCM, so this PR will fix the path in the Spack installation.  