### PR TITLE
Revert multi value

### DIFF
--- a/packages/cosmo-dycore/package.py
+++ b/packages/cosmo-dycore/package.py
@@ -61,7 +61,20 @@ class CosmoDycore(CMakePackage):
     variant('gt1', default=False, description='Build with gridtools 1.1.3')
 
     variant('slurm_bin', default='srun', description='Slurm binary on CSCS machines')
-    variant('slurm_args', default='None', multi=True, description='Additional arguments to submit tests')
+    variant('slurm_opt_partition', default='-p', description='Slurm option to specify partition for testing')
+    variant('slurm_partition', default='normal', description='Slurm partition for testing')
+
+    variant('slurm_gpu', default='-', description='Slurm GPU reservation for testing')
+
+    variant('slurm_opt_nodes', default='-n', description='Slurm option to specify number of nodes for testing')
+    variant('slurm_nodes', default='{0}', description='Pattern to specify number of nodes for testing')
+
+    variant('slurm_opt_account', default='-A', description='Slurm option to specify account for testing')
+    variant('slurm_account', default='g110', description='Slurm option to specify account for testing')
+
+    variant('slurm_opt_constraint', default='-C', description='Slurm option to specify constraints for nodes requested')
+    variant('slurm_constraint', default='gpu', description='Slurm constraints for nodes requested')
+
 
     depends_on('gridtools@1.1.3 ~cuda cuda_arch=none', when='~cuda+gt1')
     depends_on('gridtools@1.1.3 +cuda', when='+cuda+gt1')

--- a/packages/cosmo/package.py
+++ b/packages/cosmo/package.py
@@ -35,7 +35,7 @@ class Cosmo(MakefilePackage):
     maintainers = ['elsagermann']
 
     version('master', branch='master', get_full_repo=True)
-    version('dev-build', git='git@github.com:cosunae/cosmo.git', branch='revert_multi_value', get_full_repo=True)
+    version('dev-build', branch='master', get_full_repo=True)
     version('mch', git='git@github.com:MeteoSwiss-APN/cosmo.git', branch='mch', get_full_repo=True)
     version('c2sm', git='git@github.com:C2SM-RCM/cosmo.git', branch='master', get_full_repo=True)
 

--- a/packages/cosmo/package.py
+++ b/packages/cosmo/package.py
@@ -35,7 +35,7 @@ class Cosmo(MakefilePackage):
     maintainers = ['elsagermann']
 
     version('master', branch='master', get_full_repo=True)
-    version('dev-build', branch='master', get_full_repo=True)
+    version('dev-build', git='git@github.com:cosunae/cosmo.git', branch='revert_multi_value', get_full_repo=True)
     version('mch', git='git@github.com:MeteoSwiss-APN/cosmo.git', branch='mch', get_full_repo=True)
     version('c2sm', git='git@github.com:C2SM-RCM/cosmo.git', branch='master', get_full_repo=True)
 

--- a/sysconfigs/daint/packages.yaml
+++ b/sysconfigs/daint/packages.yaml
@@ -37,7 +37,7 @@ packages:
       variants: +cuda cuda_arch=60
       compiler: [gcc]
     cosmo-dycore:
-      variants: slave=daint +cuda cuda_arch=60 data_path=/scratch/snx3000/jenkins/data/cosmo/ slurm_args= "--partition=normal,-ntasks={0},--account=g110,--constraint=gpu" 
+      variants: slave=daint +cuda cuda_arch=60 data_path=/scratch/snx3000/jenkins/data/cosmo/ slurm_partition= "normal" slurm_bin= "srun" slurm_gpu= "-" slurm_opt_nodes= "-N" slurm_nodes= "{0}"  slurm_opt_account= "-A" slurm_account= "g110" slurm_opt_constraint= "-C" slurm_constraint= "gpu" 
       compiler: [gcc@8.3.0]
     cmake:
         paths:

--- a/sysconfigs/tsa/packages.yaml
+++ b/sysconfigs/tsa/packages.yaml
@@ -92,7 +92,7 @@ packages:
   libgrib1:
     variants: slave=tsa
   cosmo-dycore:
-    variants: +cuda cuda_arch=70 data_path=/scratch/jenkins/data/cosmo/ slave=tsa slurm_args= "--partition=debug,--ntasks={0},--gres=gpu:{0}"
+    variants: +cuda cuda_arch=70 data_path=/scratch/jenkins/data/cosmo/ slave=tsa slurm_bin= "srun" slurm_partition= "debug" slurm_gpu= "--gres=gpu:{0}" slurm_opt_nodes= "-n" slurm_nodes= "{0}" slurm_opt_account= "-" slurm_account= "-" slurm_opt_constraint= "-" slurm_constraint= "-"
     compiler: [gcc]
   gridtools:
     variants: +cuda cuda_arch=70


### PR DESCRIPTION
The use of multi-value variants of spack for slurm_args triggered errors with the spack uninstall, location, find,... 
Therefore we need to revert this to use individual variants for each of the slurm parameters


goes together with this: 
https://github.com/COSMO-ORG/cosmo/pull/393