### PR TITLE
Changed serialbox git url to https

### DIFF
--- a/packages/serialbox/package.py
+++ b/packages/serialbox/package.py
@@ -27,7 +27,7 @@ class Serialbox(CMakePackage):
     """Serialbox is part of the GridTools Framework. Serialbox is a serialization library and tools for C/C++, Python3 and Fortran."""
     homepage = "https://github.com/GridTools/serialbox"
     url      = "https://github.com/GridTools/serialbox/archive/v2.6.0.tar.gz"
-    git      = "git@github.com:GridTools/serialbox.git"
+    git      = "https://github.com/GridTools/serialbox.git"
 
     maintainers = ['elsagermann']
 


### PR DESCRIPTION
Since serialbox has a public repo, we can just use the https url.
This way, no working ssh key is required to connect to git.